### PR TITLE
Fix for crashing app

### DIFF
--- a/src/main/java/riotapi/Request.java
+++ b/src/main/java/riotapi/Request.java
@@ -13,31 +13,26 @@ public class Request {
 
     public static String execute(String URL) throws RiotApiException {
 
-		HttpURLConnection connection = null;
-	
+        HttpURLConnection connection = null;
+
         try {
             String requestURL = URL;
-
             URL url = new URL(requestURL);
 
             connection = (HttpURLConnection) url.openConnection();
-            
-
             connection.setRequestMethod("GET");
             connection.setInstanceFollowRedirects(false);
-           
 
             int responseCode = connection.getResponseCode();
-
             if (responseCode != 200) {
                 throw new RiotApiException(responseCode);
             }
 
             InputStream is = connection.getInputStream();
             BufferedReader rd = new BufferedReader(new InputStreamReader(is, "utf-8"));
-            String line;
             StringBuilder response = new StringBuilder();
 
+            String line;
             while ((line = rd.readLine()) != null) {
                 response.append(line);
                 response.append('\r');
@@ -45,17 +40,14 @@ public class Request {
 
             connection.disconnect();
             return response.toString();
-
         } catch (IOException ex) {
             Logger.getLogger(Request.class.getName()).log(Level.SEVERE, null, ex);
         } finally {
-			if(connection != null){
-				connection.disconnect();
-			}
-		}
+            if(connection != null){
+                connection.disconnect();
+            }
+        }
 
         return null;
-
     }
-
 }

--- a/src/main/java/riotapi/Request.java
+++ b/src/main/java/riotapi/Request.java
@@ -13,12 +13,14 @@ public class Request {
 
     public static String execute(String URL) throws RiotApiException {
 
+		HttpURLConnection connection = null;
+	
         try {
             String requestURL = URL;
 
             URL url = new URL(requestURL);
 
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection();
             
 
             connection.setRequestMethod("GET");
@@ -46,7 +48,11 @@ public class Request {
 
         } catch (IOException ex) {
             Logger.getLogger(Request.class.getName()).log(Level.SEVERE, null, ex);
-        }
+        } finally {
+			if(connection != null){
+				connection.disconnect();
+			}
+		}
 
         return null;
 


### PR DESCRIPTION
I had an issue for a long time -- my apps with this API seem to break/crash when the RiotAPI is not reachable or not working correctly for many requests. Sometimes it comes up with ConnectionExceptions or SSLExceptions like "SSL peer shut down incorrectly", but often the app would just stop working, probably because there are too many 'dead connections' still alive, eating memory and exhausting the VM.

After searching through the code of this API, I found this issue here: if an Exception happens between line 24 and 46, the connection will never be closed properly, causing it to keep dead threads alive and eat VM resources. I hope that this fix will reduce the amount of crashes I experienced with this API for long running times.

Important: Please do some additional testing before shipping this in a new version release, since this is a change to the core of this API.