### PR TITLE
Throw exception instead of returning null response from Request.execute()

### DIFF
--- a/src/main/java/riotapi/Request.java
+++ b/src/main/java/riotapi/Request.java
@@ -42,12 +42,11 @@ public class Request {
             return response.toString();
         } catch (IOException ex) {
             Logger.getLogger(Request.class.getName()).log(Level.SEVERE, null, ex);
+            throw new RiotApiException(RiotApiException.NO_INTERNET);
         } finally {
             if(connection != null){
                 connection.disconnect();
             }
         }
-
-        return null;
     }
 }

--- a/src/main/java/riotapi/RiotApiException.java
+++ b/src/main/java/riotapi/RiotApiException.java
@@ -15,6 +15,7 @@ public class RiotApiException extends Exception {
     public static final int SERVER_ERROR = 500;
     public static final int UNAVAILABLE = 503;
     public static final int PARSE_FAILURE = 600;
+    public static final int NO_INTERNET = 601;
 
     private final int errorCode;
 
@@ -41,6 +42,8 @@ public class RiotApiException extends Exception {
                 return "Unauthorized";
             case UNAVAILABLE:
                 return "Service unavailable";
+            case NO_INTERNET:
+            	return "No Internet connection";
             default:
                 return "An unknown API error occured";
         }


### PR DESCRIPTION
If you don't have internet connection (on an Android phone), the response from Request.execute() returns a null String, which Gson parses into null Maps/Lists/etc, which lead to NullPointerExceptions, ultimately crashing the app.

Not sure if creating a new type of RiotApiException is the way to go, but at least this avoids stray NPE's.