### PR TITLE
Butchers Bridge (map 14) + Preseasons

### DIFF
--- a/src/constant/Map.java
+++ b/src/constant/Map.java
@@ -30,7 +30,8 @@ public enum Map {
 		TWISTED_TREELINE_CURRENT(10, "Twisted Treeline"),
         SUMMONERS_RIFT_2014(11, "Summoner's Rift"),
 		HOWLING_ABYSS(12, "Howling Abyss"),
-		ARAM(12, "Howling Abyss");
+		ARAM(12, "Howling Abyss"),
+                BUTCHERS_BRIDGE(14,"Butcher's Bridge");
 
 	    private int id;
 	    private String name;

--- a/src/constant/Season.java
+++ b/src/constant/Season.java
@@ -17,11 +17,14 @@ package constant;
  */
 	
 public enum Season {
-	
-		Season3("SEASON3"),
+			
+		PRESEASON3("PRESEASON3"),
+                Season3("SEASON3"),
 		Season4("SEASON2014"),
 		Season5("SEASON2015"),
+		PRESEASON2014("PRESEASON2014"),
 		Season2014("SEASON2014"),
+		PRESEASON2015("PRESEASON2015"),
 		Season2015("SEASON2015"),
 		THREE("SEASON3"),
 		FOUR("SEASON2014"),


### PR DESCRIPTION
Butchers Bridge is still missing, maybe Riot forgot to add it ?  Maybe it's better to wait and see which name Riot uses for the constant.

Preseasons do exist