### PR TITLE
Add Season.CURRENT; Add Riot API IOException

### DIFF
--- a/src/constant/Season.java
+++ b/src/constant/Season.java
@@ -17,18 +17,30 @@ package constant;
  */
 	
 public enum Season {
-			
+
+		// Seasons with Number
+		SEASON3("SEASON3"),
+		SEASON4("SEASON2014"),
+		SEASON5("SEASON2015"),
+
+		// Seasons with Year
+		SEASON2013("SEASON3"),
+		SEASON2014("SEASON2014"),
+		SEASON2015("SEASON2015"),
+
+		// Preseasons
 		PRESEASON3("PRESEASON3"),
-		Season3("SEASON3"),
-		Season4("SEASON2014"),
-		Season5("SEASON2015"),
 		PRESEASON2014("PRESEASON2014"),
-		Season2014("SEASON2014"),
 		PRESEASON2015("PRESEASON2015"),
-		Season2015("SEASON2015"),
+
+		// Number
 		THREE("SEASON3"),
 		FOUR("SEASON2014"),
-		FIVE("SEASON2015");
+		FIVE("SEASON2015"),
+
+		// Current Season
+		CURRENT("SEASON2015");
+
 
 	    private String season;
 	    

--- a/src/main/java/riotapi/Request.java
+++ b/src/main/java/riotapi/Request.java
@@ -42,12 +42,11 @@ public class Request {
             return response.toString();
         } catch (IOException ex) {
             Logger.getLogger(Request.class.getName()).log(Level.SEVERE, null, ex);
+            throw new RiotApiException(RiotApiException.IOEXCEPTION);
         } finally {
             if(connection != null){
                 connection.disconnect();
             }
         }
-
-        return null;
     }
 }

--- a/src/main/java/riotapi/RiotApiException.java
+++ b/src/main/java/riotapi/RiotApiException.java
@@ -16,6 +16,7 @@ public class RiotApiException extends Exception {
     public static final int SERVER_ERROR = 500;
     public static final int UNAVAILABLE = 503;
     public static final int PARSE_FAILURE = 600;
+    public static final int IOEXCEPTION = 601;
 
     private final int errorCode;
 
@@ -32,6 +33,8 @@ public class RiotApiException extends Exception {
                 return "Forbidden";
             case DATA_NOT_FOUND:
                 return "Requested data not found";
+            case IOEXCEPTION:
+            	return "I/O Exception thrown";
             case PARSE_FAILURE:
                 return "Failed to parse Riot's JSON response";
             case UNPROCESSABLE_ENTITY:


### PR DESCRIPTION
I got the idea to add a Season.CURRENT constant, which always refers to
the current season. This means, the value of this constant will update for
Preseason2016 and Season2016 as soon as they arrive. This way
applications don't have to care about updating their constants, if they
only always want data from the current season.

Also cleaned up the other enums.