### PR TITLE
JavaDoc, Optimizations & Clean Up

### DIFF
--- a/src/constant/GameMode.java
+++ b/src/constant/GameMode.java
@@ -17,23 +17,28 @@ package constant;
  */
 
 public enum GameMode {
-	    
-		CLASSIC("Classic"),
-		ODIN("Dominion/Crystal Scar"),
-		ARAM("ARAM"),
-		TUTORIAL("Tutorial"),
-		ONEFORALL("One for All"),
-		ASCENSION("Ascension"),
-		FIRSTBLOOD("Snowdown Showdown"),
-		KINGPORO("King Poro");
 
-	    private String name;
-	    
-	    GameMode(String name) {
-	        this.name = name;
-	    }
+	ARAM("ARAM"),
+	ASCENSION("Ascension"),
+	CLASSIC("Classic"),
+	FIRSTBLOOD("Snowdown Showdown"),
+	KINGPORO("King Poro"),
+	ODIN("Dominion/Crystal Scar"),
+	ONEFORALL("One for All"),
+	TUTORIAL("Tutorial");
 
-	    public String getName() {
-	        return name;
-	    }	    
+	private String name;
+
+	GameMode(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/GameType.java
+++ b/src/constant/GameType.java
@@ -15,20 +15,25 @@ package constant;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-	
-public enum GameType {
-	    
-		CUSTOM_GAME("Custom"),
-		TUTORIAL_GAME("Tutorial"),
-		MATCHED_GAME("All");
-		
-	    private String name;
-	    
-	    GameType(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+public enum GameType {
+
+	CUSTOM_GAME("Custom"),
+	TUTORIAL_GAME("Tutorial"),
+	MATCHED_GAME("All");
+
+	private String name;
+
+	GameType(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/Map.java
+++ b/src/constant/Map.java
@@ -19,47 +19,48 @@ import main.java.riotapi.RiotStringNotFound;
  */
 
 public enum Map {
-	    
-		SUMMONERS_RIFT_SUMMER(1, "Summoner's Rift"),
-		SUMMONERS_RIFT_AUTUMN(2, "Summoner's Rift"),
-		PROVING_GROUNDS(3, "Proving Grounds"),
-		TUTORIAL(3, "Proving Grounds"),
-		TWISTED_TREELINE_ORIGINAL(4, "Twisted Treeline"),
-		CRYSTAL_SCAR(8, "The Crystal Scar"),
-		DOMINION(8, "The Crystal Scar"),
-		TWISTED_TREELINE_CURRENT(10, "Twisted Treeline"),
-        SUMMONERS_RIFT_2014(11, "Summoner's Rift"),
-		HOWLING_ABYSS(12, "Howling Abyss"),
-		ARAM(12, "Howling Abyss"),
-		BUTCHERS_BRIDGE(14,"Butcher's Bridge");
 
-	    private int id;
-	    private String name;
-	    
-	    Map(int id, String name) {
-	        this.id = id;
-	        this.name = name;
-	    }
+	ARAM(12, "Howling Abyss"),
+	BUTCHERS_BRIDGE(14,"Butcher's Bridge"),
+	CRYSTAL_SCAR(8, "The Crystal Scar"),
+	DOMINION(8, "The Crystal Scar"),
+	HOWLING_ABYSS(12, "Howling Abyss"),
+	PROVING_GROUNDS(3, "Proving Grounds"),
+    SUMMONERS_RIFT_2014(11, "Summoner's Rift"),
+	SUMMONERS_RIFT_AUTUMN(2, "Summoner's Rift"),
+	SUMMONERS_RIFT_SUMMER(1, "Summoner's Rift"),
+	TUTORIAL(3, "Proving Grounds"),
+	TWISTED_TREELINE_CURRENT(10, "Twisted Treeline"),
+	TWISTED_TREELINE_ORIGINAL(4, "Twisted Treeline");
 
-	    public int getId() {
-	        return id;
-	    }
-	    
-	    public String getName() {
-	    	return name;
-	    }
-	    
-	    public String toString() {
-	    	return name;
-	    }
-	    
-	    public static String getNameById(int mapId) throws RiotStringNotFound {
-	    	Map[] maps = Map.values();
-	    	for(Map map : maps) {
-	    		if(mapId == map.getId()) {
-	    			return map.getName();
-	    		}
-	    	} throw new RiotStringNotFound("Could not find map " + mapId);
-	    }
+	private int id;
+	private String name;
 
+	public static String getNameById(int mapId) throws RiotStringNotFound {
+		Map[] maps = Map.values();
+		for (Map map : maps) {
+			if (mapId == map.getId()) {
+				return map.getName();
+			}
+		}
+		throw new RiotStringNotFound("Could not find map " + mapId);
+	}
+
+	Map(int id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/PlatformId.java
+++ b/src/constant/PlatformId.java
@@ -17,32 +17,37 @@ package constant;
  */
 
 public enum PlatformId {
-	    
-		NA("NA1", "na"),
-		BR("BR1", "br"),
-		LAN("LA1", "lan"),
-		LAS("LA2", "las"),
-		OCE("OC1", "oce"),
-		EUNE("EUN1", "eune"),
-		EUW("EUW1", "euw"),
-		KR("KR", "kr"),
-		RU("RU", "ru"),
-		TR("TR1", "tr"),
-		PBE("PBE1", "pbe");
-		
-	    private String id;
-	    private String name;
-	    
-	    PlatformId(String id, String name) {
-	        this.id = id;
-	        this.name = name;
-	    }
 
-	    public String getId() {
-	        return id;
-	    }	    
-	    
-	    public String getName() {
-	    	return name;
-	    }
+	BR("BR1", "br"),
+	EUNE("EUN1", "eune"),
+	EUW("EUW1", "euw"),
+	KR("KR", "kr"),
+	LAN("LA1", "lan"),
+	LAS("LA2", "las"),
+	NA("NA1", "na"),
+	OCE("OC1", "oce"),
+	PBE("PBE1", "pbe"),
+	RU("RU", "ru"),
+	TR("TR1", "tr");
+
+	private String id;
+	private String name;
+
+	PlatformId(String id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/PlayerStatSummaryType.java
+++ b/src/constant/PlayerStatSummaryType.java
@@ -15,39 +15,44 @@ package constant;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-	
-public enum PlayerStatSummaryType {
-	    
-		Unranked("Summoner's Rift Unranked"),
-		Unranked3x3("Twisted Treeline Unranked"),
-		OdinUnranked("Dominion/Crystal Scar"),
-		AramUnranked5x5("ARAM / Howling Abyss"),
-		CoopVsAI("Summoner's Rift/Crystal Scar Bots"),
-		CoopVsAI3x3("Twisted Treeline Bots"),
-		RankedSolo5x5("Summoner's Rift Ranked Solo"),
-		RankedTeam3x3("Twisted Treeline Ranked Team"),
-		RankedTeam5x5("Summoner's Rift Ranked Team"),
-		OneForAll5x5("One for All"),
-		FirstBlood1x1("Snowdown Showdown 1x1"),
-		FirstBlood2x2("Snowdown Showdown 2x2"),
-		SummonersRift6x6("Hexakill"),
-		CAP5x5("Team Builder"),
-		URF("Ultra Rapid Fire"),
-		URFBots("Ultra Rapid Fire Bots"),
-		NightmareBot("Summoner's Rift Nightmare Bots"),
-		Ascension("Ascension"),
-		Hexakill("Twisted Treeline 6x6 Hexakill"),
-		KingPoro("King Poro"),
-		CounterPick("Nemesis"),
-		Bilgewater("Black Market Brawlers");
-		
-	    private String name;
-	    
-	    PlayerStatSummaryType(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+public enum PlayerStatSummaryType {
+
+	Unranked("Summoner's Rift Unranked"),
+	Unranked3x3("Twisted Treeline Unranked"),
+	OdinUnranked("Dominion/Crystal Scar"),
+	AramUnranked5x5("ARAM / Howling Abyss"),
+	CoopVsAI("Summoner's Rift/Crystal Scar Bots"),
+	CoopVsAI3x3("Twisted Treeline Bots"),
+	RankedSolo5x5("Summoner's Rift Ranked Solo"),
+	RankedTeam3x3("Twisted Treeline Ranked Team"),
+	RankedTeam5x5("Summoner's Rift Ranked Team"),
+	OneForAll5x5("One for All"),
+	FirstBlood1x1("Snowdown Showdown 1x1"),
+	FirstBlood2x2("Snowdown Showdown 2x2"),
+	SummonersRift6x6("Hexakill"),
+	CAP5x5("Team Builder"),
+	URF("Ultra Rapid Fire"),
+	URFBots("Ultra Rapid Fire Bots"),
+	NightmareBot("Summoner's Rift Nightmare Bots"),
+	Ascension("Ascension"),
+	Hexakill("Twisted Treeline 6x6 Hexakill"),
+	KingPoro("King Poro"),
+	CounterPick("Nemesis"),
+	Bilgewater("Black Market Brawlers");
+
+	private String name;
+
+	PlayerStatSummaryType(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/QueueType.java
+++ b/src/constant/QueueType.java
@@ -17,71 +17,73 @@ import main.java.riotapi.RiotStringNotFound;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-	
+
 public enum QueueType {
-	    
-		CUSTOM("Custom", 0),
-		NORMAL_5x5_BLIND("Normal 5v5 Blind Pick", 2),
-		BOT_5x5("Historical Summoner's Rift Coop vs AI", 7),
-		BOT_5x5_INTRO("Summoner's Rift Coop vs AI Intro Bot", 31),
-		BOT_5x5_BEGINNER("Summoner's Rift Coop vs AI Beginner Bot", 32),
-		BOT_5x5_INTERMEDIATE("Historical Summoner's Rift Coop vs AI Intermediate Bot", 33),
-		NORMAL_3x3("Normal 3v3", 8),
-		NORMAL_5x5_DRAFT("Normal 5v5 Draft Pick", 14),
-		ODIN_5x5_BLIND("Dominion 5v5 Blind Pick", 16),
-		ODIN_5x5_DRAFT("Dominion 5v5 Draft Pick", 17),
-		BOT_ODIN_5x5("Dominion Coop vs AI", 25),
-		RANKED_SOLO_5x5("Ranked Solo 5v5", 4),
-		RANKED_PREMADE_3x3("Ranked Premade 3v3", 9),
-		RANKED_PREMADE_5x5("Ranked Premade 5v5", 6),
-		RANKED_TEAM_3x3("Ranked Team 3v3", 41),
-		RANKED_TEAM_5x5("Ranked Team 5v5", 42),
-		BOT_TT_3x3("Twisted Treeline Coop vs AI", 52),
-		GROUP_FINDER_5x5("Team Builder", 61),
-		ARAM_5x5("ARAM", 65),
-		ONEFORALL_5x5("One for All", 70),
-        ONEFORALL_MIRRORMODE_5x5("One for All: Mirror Mode", 70),
-		FIRSTBLOOD_1x1("Snowdown Showdown 1v1", 72),
-		FIRSTBLOOD_2x2("Snowdown Showdown 2v2", 73),
-		SR_6x6("Hexakill", 75),
-		URF_5x5("Ultra Rapid Fire", 76),
-		BOT_URF_5x5("Ultra Rapid Fire games played against AI", 83),
-		NIGHTMARE_BOT_5x5_RANK1("Doom Bots Rank 1", 91),
-		NIGHTMARE_BOT_5x5_RANK2("Doom Bots Rank 2", 92),
-		NIGHTMARE_BOT_5x5_RANK5("Doom Bots Rank 5", 93),
-		ASCENSION_5x5("Ascension", 96),
-		HEXAKILL("Twisted Treeline 6x6 Hexakill", 98),
-		BILGEWATER_ARAM_5x5("Butcher's Bridge", 100),
-		KING_PORO_5x5("King Poro", 300),
-		COUNTER_PICK("Nemesis Draft", 310),
-		BILGEWATER_5x5("Black Market Brawlers", 313);
 
-	    private String name;
-	    private int gameQueueConfigId;
-	    
-	    public static String getQueueNameByConfigId(int gameQueueConfigId) throws RiotStringNotFound {
-	    	QueueType[] queueTypes = QueueType.values();
-	    	for(QueueType queueType : queueTypes) {
-	    		if(queueType.getGameQueueConfigId() == gameQueueConfigId) {
-	    			return queueType.getName();
-	    		}
-	    	} throw new RiotStringNotFound("Could not find queue " + gameQueueConfigId);
-	    }
-	    
-	    QueueType(String name, int gameQueueConfigId) {
-	        this.name = name;
-	        this.gameQueueConfigId = gameQueueConfigId;
-	    }
+	CUSTOM("Custom", 0),
+	NORMAL_5x5_BLIND("Normal 5v5 Blind Pick", 2),
+	BOT_5x5("Historical Summoner's Rift Coop vs AI", 7),
+	BOT_5x5_INTRO("Summoner's Rift Coop vs AI Intro Bot", 31),
+	BOT_5x5_BEGINNER("Summoner's Rift Coop vs AI Beginner Bot", 32),
+	BOT_5x5_INTERMEDIATE("Historical Summoner's Rift Coop vs AI Intermediate Bot", 33),
+	NORMAL_3x3("Normal 3v3", 8),
+	NORMAL_5x5_DRAFT("Normal 5v5 Draft Pick", 14),
+	ODIN_5x5_BLIND("Dominion 5v5 Blind Pick", 16),
+	ODIN_5x5_DRAFT("Dominion 5v5 Draft Pick", 17),
+	BOT_ODIN_5x5("Dominion Coop vs AI", 25),
+	RANKED_SOLO_5x5("Ranked Solo 5v5", 4),
+	RANKED_PREMADE_3x3("Ranked Premade 3v3", 9),
+	RANKED_PREMADE_5x5("Ranked Premade 5v5", 6),
+	RANKED_TEAM_3x3("Ranked Team 3v3", 41),
+	RANKED_TEAM_5x5("Ranked Team 5v5", 42),
+	BOT_TT_3x3("Twisted Treeline Coop vs AI", 52),
+	GROUP_FINDER_5x5("Team Builder", 61),
+	ARAM_5x5("ARAM", 65),
+	ONEFORALL_5x5("One for All", 70),
+    ONEFORALL_MIRRORMODE_5x5("One for All: Mirror Mode", 70),
+	FIRSTBLOOD_1x1("Snowdown Showdown 1v1", 72),
+	FIRSTBLOOD_2x2("Snowdown Showdown 2v2", 73),
+	SR_6x6("Hexakill", 75),
+	URF_5x5("Ultra Rapid Fire", 76),
+	BOT_URF_5x5("Ultra Rapid Fire games played against AI", 83),
+	NIGHTMARE_BOT_5x5_RANK1("Doom Bots Rank 1", 91),
+	NIGHTMARE_BOT_5x5_RANK2("Doom Bots Rank 2", 92),
+	NIGHTMARE_BOT_5x5_RANK5("Doom Bots Rank 5", 93),
+	ASCENSION_5x5("Ascension", 96),
+	HEXAKILL("Twisted Treeline 6x6 Hexakill", 98),
+	BILGEWATER_ARAM_5x5("Butcher's Bridge", 100),
+	KING_PORO_5x5("King Poro", 300),
+	COUNTER_PICK("Nemesis Draft", 310),
+	BILGEWATER_5x5("Black Market Brawlers", 313);
 
-	    public String getName() {
-	        return name;
-	    }	    
-	    
-	    public int getGameQueueConfigId() {
-	    	return gameQueueConfigId;
-	    }
-	    
-	    public String toString() {
-	    	return name;
-	    }
+	private String name;
+	private int gameQueueConfigId;
+
+	public static String getQueueNameByConfigId(int gameQueueConfigId) throws RiotStringNotFound {
+		QueueType[] queueTypes = QueueType.values();
+		for (QueueType queueType : queueTypes) {
+			if (queueType.getGameQueueConfigId() == gameQueueConfigId) {
+				return queueType.getName();
+			}
+		}
+		throw new RiotStringNotFound("Could not find queue " + gameQueueConfigId);
+	}
+
+	QueueType(String name, int gameQueueConfigId) {
+		this.name = name;
+		this.gameQueueConfigId = gameQueueConfigId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getGameQueueConfigId() {
+		return gameQueueConfigId;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/Region.java
+++ b/src/constant/Region.java
@@ -39,8 +39,16 @@ public enum Region {
 		this.region = region;
 	}
 
+	public String getEndpoint(boolean withRegion) {
+		String url = "https://" + endpoint + "/api/lol/";
+		if (withRegion) {
+			url += getName();
+		}
+		return url;
+	}
+
 	public String getEndpoint() {
-		return "https://" + endpoint + "/api/lol/";
+		return getEndpoint(true);
 	}
 
 	public String getName() {

--- a/src/constant/Region.java
+++ b/src/constant/Region.java
@@ -17,33 +17,38 @@ package constant;
  */
 
 public enum Region {
-	     
-		BR("br.api.pvp.net", "br"),
-		EUNE("eune.api.pvp.net", "eune"),
-		EUW("euw.api.pvp.net", "euw"),
-		KR("kr.api.pvp.net", "kr"),
-		LAS("las.api.pvp.net", "las"),
-		LAN("lan.api.pvp.net", "lan"),
-		NA("na.api.pvp.net", "na"),
-		OCE("oce.api.pvp.net", "oce"),
-		TR("tr.api.pvp.net", "tr"),
-		RU("ru.api.pvp.net", "ru"),
-		PBE("pbe.api.pvp.net", "pbe"),
-		GLOBAL("global.api.pvp.net", "global");
 
-	    private String endpoint;
-	    private String region;
-	    
-	    Region(String endpoint, String region) {
-	        this.endpoint = endpoint;
-	        this.region = region;
-	    }
+	BR("br.api.pvp.net", "br"),
+	EUNE("eune.api.pvp.net", "eune"),
+	EUW("euw.api.pvp.net", "euw"),
+	KR("kr.api.pvp.net", "kr"),
+	LAS("las.api.pvp.net", "las"),
+	LAN("lan.api.pvp.net", "lan"),
+	NA("na.api.pvp.net", "na"),
+	OCE("oce.api.pvp.net", "oce"),
+	PBE("pbe.api.pvp.net", "pbe"),
+	RU("ru.api.pvp.net", "ru"),
+	TR("tr.api.pvp.net", "tr"),
+	GLOBAL("global.api.pvp.net", "global");
 
-	    public String getEndpoint() {
-	        return "https://" + endpoint + "/api/lol/";
-	    }
-	    
-	    public String getName() {
-	        return region;
-	    }
+	private String endpoint;
+	private String region;
+
+	Region(String endpoint, String region) {
+		this.endpoint = endpoint;
+		this.region = region;
+	}
+
+	public String getEndpoint() {
+		return "https://" + endpoint + "/api/lol/";
+	}
+
+	public String getName() {
+		return region;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/Season.java
+++ b/src/constant/Season.java
@@ -15,40 +15,44 @@ package constant;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-	
+
 public enum Season {
 
-		// Seasons with Number
-		SEASON3("SEASON3"),
-		SEASON4("SEASON2014"),
-		SEASON5("SEASON2015"),
+	// Seasons with Number
+	SEASON3("SEASON3"),
+	SEASON4("SEASON2014"),
+	SEASON5("SEASON2015"),
 
-		// Seasons with Year
-		SEASON2013("SEASON3"),
-		SEASON2014("SEASON2014"),
-		SEASON2015("SEASON2015"),
+	// Seasons with Year
+	SEASON2013("SEASON3"),
+	SEASON2014("SEASON2014"),
+	SEASON2015("SEASON2015"),
 
-		// Preseasons
-		PRESEASON3("PRESEASON3"),
-		PRESEASON2014("PRESEASON2014"),
-		PRESEASON2015("PRESEASON2015"),
+	// Preseasons
+	PRESEASON3("PRESEASON3"),
+	PRESEASON2014("PRESEASON2014"),
+	PRESEASON2015("PRESEASON2015"),
 
-		// Number
-		THREE("SEASON3"),
-		FOUR("SEASON2014"),
-		FIVE("SEASON2015"),
+	// Number
+	THREE("SEASON3"),
+	FOUR("SEASON2014"),
+	FIVE("SEASON2015"),
 
-		// Current Season
-		CURRENT("SEASON2015");
+	// Current Season
+	CURRENT("SEASON2015");
 
+	private String season;
 
-	    private String season;
-	    
-	    Season(String season) {
-	        this.season = season;
-	    }
+	Season(String season) {
+		this.season = season;
+	}
 
-	    public String getName() {
-	        return season;
-	    }	    
+	public String getName() {
+		return season;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/SubType.java
+++ b/src/constant/SubType.java
@@ -17,38 +17,43 @@ package constant;
  */
 
 public enum SubType {
-	    
-		NONE("Custom"),
-		NORMAL("Summoner's Rift Unranked"),
-		NORMAL_3x3("Twisted Treeline Unranked"),
-		ODIN_UNRANKED("Dominion/Crystal Scar"),
-		ARAM_UNRANKED_5x5("ARAM / Howling Abyss"),
-		BOT("Summoner's Rift/Crystal Scar Bots"),
-		BOT_3x3("Twisted Treeline Bots"),
-		RANKED_SOLO_5x5("Summoner's Rift Ranked Solo"),
-		RANKED_TEAM_3x3("Twisted Treeline Ranked Team"),
-		RANKED_TEAM_5x5("Summoner's Rift Ranked Team"),
-		ONEFORALL_5x5("One for All"),
-		FIRSTBLOOD_1x1("Snowdown Showdown 1x1"),
-		FIRSTBLOOD_2x2("Snowdown Showdown 2x2"),
-		SR_6x6("Hexakill"),
-		CAP_5x5("Team Builder"),
-		URF("Ultra Rapid Fire"),
-		URF_BOT("Ultra Rapid Fire Bots"),
-		NIGHTMARE_BOT("Summoner's Rift Doom Bots"),
-		ASCENSION("Ascension"),
-		HEXAKILL("Twisted Treeline 6x6 Hexakill"),
-		KING_PORO("King Poro"),
-		COUNTER_PICK("Nemesis Draft"),
-		BILGEWATER("Black Market Brawlers");
-		
-	    private String name;
-	    
-	    SubType(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	NONE("Custom"),
+	NORMAL("Summoner's Rift Unranked"),
+	NORMAL_3x3("Twisted Treeline Unranked"),
+	ODIN_UNRANKED("Dominion/Crystal Scar"),
+	ARAM_UNRANKED_5x5("ARAM / Howling Abyss"),
+	BOT("Summoner's Rift/Crystal Scar Bots"),
+	BOT_3x3("Twisted Treeline Bots"),
+	RANKED_SOLO_5x5("Summoner's Rift Ranked Solo"),
+	RANKED_TEAM_3x3("Twisted Treeline Ranked Team"),
+	RANKED_TEAM_5x5("Summoner's Rift Ranked Team"),
+	ONEFORALL_5x5("One for All"),
+	FIRSTBLOOD_1x1("Snowdown Showdown 1x1"),
+	FIRSTBLOOD_2x2("Snowdown Showdown 2x2"),
+	SR_6x6("Hexakill"),
+	CAP_5x5("Team Builder"),
+	URF("Ultra Rapid Fire"),
+	URF_BOT("Ultra Rapid Fire Bots"),
+	NIGHTMARE_BOT("Summoner's Rift Doom Bots"),
+	ASCENSION("Ascension"),
+	HEXAKILL("Twisted Treeline 6x6 Hexakill"),
+	KING_PORO("King Poro"),
+	COUNTER_PICK("Nemesis Draft"),
+	BILGEWATER("Black Market Brawlers");
+
+	private String name;
+
+	SubType(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/staticdata/ChampData.java
+++ b/src/constant/staticdata/ChampData.java
@@ -17,30 +17,35 @@ package constant.staticdata;
  */
 
 public enum ChampData {
-	    
-		ALL("all"),
-		ALLYTIPS("allytips"),
-		ALTIMAGES("altimages"),
-		BLURB("blurb"),
-		ENEMYTIPS("enemytips"),
-		IMAGE("image"),
-		INFO("info"),
-		LORE("lore"),
-		PARTYPE("partype"),
-		PASSIVE("passive"),
-		RECOMMENDED("recommended"),
-		SKINS("skins"),
-		SPELLS("spells"),
-		STATS("stats"),
-		TAGS("tags");
-		
-	    private String name;
-	    
-	    ChampData(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	ALL("all"),
+	ALLYTIPS("allytips"),
+	ALTIMAGES("altimages"),
+	BLURB("blurb"),
+	ENEMYTIPS("enemytips"),
+	IMAGE("image"),
+	INFO("info"),
+	LORE("lore"),
+	PARTYPE("partype"),
+	PASSIVE("passive"),
+	RECOMMENDED("recommended"),
+	SKINS("skins"),
+	SPELLS("spells"),
+	STATS("stats"),
+	TAGS("tags");
+
+	private String name;
+
+	ChampData(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/staticdata/ItemData.java
+++ b/src/constant/staticdata/ItemData.java
@@ -17,34 +17,39 @@ package constant.staticdata;
  */
 
 public enum ItemData {
-	    
-		ALL("all"),
-		COLLOQ("colloq"),
-		CONSUME_ON_FULL("consumeOnFull"),
-		CONSUMED("consumed"),
-		DEPTH("depth"),
-		FROM("from"),
-		GOLD("gold"),
-		HIDE_FROM_ALL("hideFromAll"),
-		IMAGE("image"),
-		IN_STORE("inStore"),
-		INTO("into"),
-		MAPS("maps"),
-		REQUIRED_CHAMPION("requiredChampion"),
-		SANITIZED_DESCRIPTION("sanitizedDescription"),
-		SPECIAL_RECIPE("specialRecipe"),
-		STACKS("stacks"),
-		STATS("stats"),
-		TAGS("tags"),
-		TREE("tree");
-		
-	    private String name;
-	    
-	    ItemData(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	ALL("all"),
+	COLLOQ("colloq"),
+	CONSUME_ON_FULL("consumeOnFull"),
+	CONSUMED("consumed"),
+	DEPTH("depth"),
+	FROM("from"),
+	GOLD("gold"),
+	HIDE_FROM_ALL("hideFromAll"),
+	IMAGE("image"),
+	IN_STORE("inStore"),
+	INTO("into"),
+	MAPS("maps"),
+	REQUIRED_CHAMPION("requiredChampion"),
+	SANITIZED_DESCRIPTION("sanitizedDescription"),
+	SPECIAL_RECIPE("specialRecipe"),
+	STACKS("stacks"),
+	STATS("stats"),
+	TAGS("tags"),
+	TREE("tree");
+
+	private String name;
+
+	ItemData(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/staticdata/ItemListData.java
+++ b/src/constant/staticdata/ItemListData.java
@@ -17,35 +17,40 @@ package constant.staticdata;
  */
 
 public enum ItemListData {
-	    
-		ALL("all"),
-		COLLOQ("colloq"),
-		CONSUME_ON_FULL("consumeOnFull"),
-		CONSUMED("consumed"),
-		DEPTH("depth"),
-		FROM("from"),
-		GOLD("gold"),
-		GROUPS("groups"),
-		HIDE_FROM_ALL("hideFromAll"),
-		IMAGE("image"),
-		IN_STORE("inStore"),
-		INTO("into"),
-		MAPS("maps"),
-		REQUIRED_CHAMPION("requiredChampion"),
-		SANITIZED_DESCRIPTION("sanitizedDescription"),
-		SPECIAL_RECIPE("specialRecipe"),
-		STACKS("stacks"),
-		STATS("stats"),
-		TAGS("tags"),
-		TREE("tree");
-		
-	    private String name;
-	    
-	    ItemListData(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	ALL("all"),
+	COLLOQ("colloq"),
+	CONSUME_ON_FULL("consumeOnFull"),
+	CONSUMED("consumed"),
+	DEPTH("depth"),
+	FROM("from"),
+	GOLD("gold"),
+	GROUPS("groups"),
+	HIDE_FROM_ALL("hideFromAll"),
+	IMAGE("image"),
+	IN_STORE("inStore"),
+	INTO("into"),
+	MAPS("maps"),
+	REQUIRED_CHAMPION("requiredChampion"),
+	SANITIZED_DESCRIPTION("sanitizedDescription"),
+	SPECIAL_RECIPE("specialRecipe"),
+	STACKS("stacks"),
+	STATS("stats"),
+	TAGS("tags"),
+	TREE("tree");
+
+	private String name;
+
+	ItemListData(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/staticdata/MasteryData.java
+++ b/src/constant/staticdata/MasteryData.java
@@ -17,20 +17,25 @@ package constant.staticdata;
  */
 
 public enum MasteryData {
-	    
-		ALL("all"),
-		IMAGE("image"),
-		PREREQ("prereq"),
-		RANKS("ranks"),
-		SANITIZED_DESCRIPTION("sanitizedDescription");
-		
-	    private String name;
-	    
-	    MasteryData(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	ALL("all"),
+	IMAGE("image"),
+	PREREQ("prereq"),
+	RANKS("ranks"),
+	SANITIZED_DESCRIPTION("sanitizedDescription");
+
+	private String name;
+
+	MasteryData(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/staticdata/MasteryListData.java
+++ b/src/constant/staticdata/MasteryListData.java
@@ -17,21 +17,26 @@ package constant.staticdata;
  */
 
 public enum MasteryListData {
-	    
-		ALL("all"),
-		IMAGE("image"),
-		PREREQ("prereq"),
-		RANKS("ranks"),
-		SANITIZED_DESCRIPTION("sanitizedDescription"),
-		TREE("tree");
-		
-	    private String name;
-	    
-	    MasteryListData(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	ALL("all"),
+	IMAGE("image"),
+	PREREQ("prereq"),
+	RANKS("ranks"),
+	SANITIZED_DESCRIPTION("sanitizedDescription"),
+	TREE("tree");
+
+	private String name;
+
+	MasteryListData(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/staticdata/RuneData.java
+++ b/src/constant/staticdata/RuneData.java
@@ -17,33 +17,38 @@ package constant.staticdata;
  */
 
 public enum RuneData {
-	    
-		ALL("all"),
-		COLLOQ("colloq"),
-		CONSUME_ON_FULL("consumeOnFull"),
-		CONSUMED("consumed"),
-		DEPTH("depth"),
-		FROM("from"),
-		GOLD("gold"),
-		HIDE_FROM_ALL("hideFromAll"),
-		IMAGE("image"),
-		IN_STORE("inStore"),
-		INTO("into"),
-		MAPS("maps"),
-		REQUIRED_CHAMPION("requiredChampion"),
-		SANITIZED_DESCRIPTION("sanitizedDescription"),
-		SPECIAL_RECIPE("specialRecipe"),
-		STACKS("stacks"),
-		STATS("stats"),
-		TAGS("tags");
-		
-	    private String name;
-	    
-	    RuneData(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	ALL("all"),
+	COLLOQ("colloq"),
+	CONSUME_ON_FULL("consumeOnFull"),
+	CONSUMED("consumed"),
+	DEPTH("depth"),
+	FROM("from"),
+	GOLD("gold"),
+	HIDE_FROM_ALL("hideFromAll"),
+	IMAGE("image"),
+	IN_STORE("inStore"),
+	INTO("into"),
+	MAPS("maps"),
+	REQUIRED_CHAMPION("requiredChampion"),
+	SANITIZED_DESCRIPTION("sanitizedDescription"),
+	SPECIAL_RECIPE("specialRecipe"),
+	STACKS("stacks"),
+	STATS("stats"),
+	TAGS("tags");
+
+	private String name;
+
+	RuneData(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/staticdata/RuneListData.java
+++ b/src/constant/staticdata/RuneListData.java
@@ -17,34 +17,39 @@ package constant.staticdata;
  */
 
 public enum RuneListData {
-	    
-		ALL("all"),
-		BASIC("basic"),
-		COLLOQ("colloq"),
-		CONSUME_ON_FULL("consumeOnFull"),
-		CONSUMED("consumed"),
-		DEPTH("depth"),
-		FROM("from"),
-		GOLD("gold"),
-		HIDE_FROM_ALL("hideFromAll"),
-		IMAGE("image"),
-		IN_STORE("inStore"),
-		INTO("into"),
-		MAPS("maps"),
-		REQUIRED_CHAMPION("requiredChampion"),
-		SANITIZED_DESCRIPTION("sanitizedDescription"),
-		SPECIAL_RECIPE("specialRecipe"),
-		STACKS("stacks"),
-		STATS("stats"),
-		TAGS("tags");
-		
-	    private String name;
-	    
-	    RuneListData(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	ALL("all"),
+	BASIC("basic"),
+	COLLOQ("colloq"),
+	CONSUME_ON_FULL("consumeOnFull"),
+	CONSUMED("consumed"),
+	DEPTH("depth"),
+	FROM("from"),
+	GOLD("gold"),
+	HIDE_FROM_ALL("hideFromAll"),
+	IMAGE("image"),
+	IN_STORE("inStore"),
+	INTO("into"),
+	MAPS("maps"),
+	REQUIRED_CHAMPION("requiredChampion"),
+	SANITIZED_DESCRIPTION("sanitizedDescription"),
+	SPECIAL_RECIPE("specialRecipe"),
+	STACKS("stacks"),
+	STATS("stats"),
+	TAGS("tags");
+
+	private String name;
+
+	RuneListData(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/constant/staticdata/SpellData.java
+++ b/src/constant/staticdata/SpellData.java
@@ -17,35 +17,40 @@ package constant.staticdata;
  */
 
 public enum SpellData {
-	    
-		ALL("all"),
-		COOLDOWN("cooldown"),
-		COOLDOWN_BURN("cooldownBurn"),
-		COST("cost"),
-		COST_BURN("costBurn"),
-		COST_TYPE("costType"),
-		EFFECT("effect"),
-		EFFECT_BURN("effectBurn"),
-		IMAGE("image"),
-		KEY("key"),
-		LEVELTIP("leveltip"),
-		MAXRANK("maxrank"),
-		MODES("modes"),
-		RANGE("range"),
-		RANGE_BURN("rangeBurn"),
-		RESOURCE("resource"),
-		SANITIZED_DESCRIPTION("sanitizedDescription"),
-		SANITIZED_TOOLTIP("sanitizedTooltip"),
-		TOOLTIP("tooltip"),
-		VARS("vars");
-		
-	    private String name;
-	    
-	    SpellData(String name) {
-	        this.name = name;
-	    }
 
-	    public String getName() {
-	        return name;
-	    }	    
+	ALL("all"),
+	COOLDOWN("cooldown"),
+	COOLDOWN_BURN("cooldownBurn"),
+	COST("cost"),
+	COST_BURN("costBurn"),
+	COST_TYPE("costType"),
+	EFFECT("effect"),
+	EFFECT_BURN("effectBurn"),
+	IMAGE("image"),
+	KEY("key"),
+	LEVELTIP("leveltip"),
+	MAXRANK("maxrank"),
+	MODES("modes"),
+	RANGE("range"),
+	RANGE_BURN("rangeBurn"),
+	RESOURCE("resource"),
+	SANITIZED_DESCRIPTION("sanitizedDescription"),
+	SANITIZED_TOOLTIP("sanitizedTooltip"),
+	TOOLTIP("tooltip"),
+	VARS("vars");
+
+	private String name;
+
+	SpellData(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/main/java/riotapi/ChampionApi.java
+++ b/src/main/java/riotapi/ChampionApi.java
@@ -25,8 +25,12 @@ final class ChampionApi {
 
 	private static final String VERSION = "/v1.2/";
 
-	public static ChampionList getChampions(String endpoint, String region, String key) throws RiotApiException {
-		String url = endpoint + region + VERSION + "champion?api_key=" + key;
+	public static ChampionList getChampions(String endpoint, String region, String key, boolean freeToPlay) throws RiotApiException {
+		String url = endpoint + region + VERSION + "champion?";
+		if (!freeToPlay) {
+			url += "freeToPlay=" + freeToPlay + "&";
+		}
+		url += "api_key=" + key;
 
 		ChampionList championList = null;
 		try {
@@ -41,20 +45,8 @@ final class ChampionApi {
 		return championList;
 	}
 
-	public static ChampionList getChampions(String endpoint, String region, String key, boolean freeToPlay) throws RiotApiException {
-		String url = endpoint + region + VERSION + "champion?freeToPlay=" + freeToPlay + "&api_key=" + key;
-
-		ChampionList championList = null;
-		try {
-			championList = new Gson().fromJson(Request.execute(url), ChampionList.class);
-		} catch (JsonSyntaxException e) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-		if (championList == null) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-
-		return championList;
+	public static ChampionList getChampions(String endpoint, String region, String key) throws RiotApiException {
+		return getChampions(endpoint, region, key, false);
 	}
 
 	public static Champion getChampionById(String endpoint, String region, String key, int champId) throws RiotApiException {

--- a/src/main/java/riotapi/ChampionApi.java
+++ b/src/main/java/riotapi/ChampionApi.java
@@ -18,6 +18,7 @@ package main.java.riotapi;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
+import constant.Region;
 import dto.Champion.Champion;
 import dto.Champion.ChampionList;
 
@@ -25,8 +26,8 @@ final class ChampionApi {
 
 	private static final String VERSION = "/v1.2/";
 
-	public static ChampionList getChampions(String endpoint, String region, String key, boolean freeToPlay) throws RiotApiException {
-		String url = endpoint + region + VERSION + "champion?";
+	public static ChampionList getChampions(Region region, String key, boolean freeToPlay) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "champion?";
 		if (!freeToPlay) {
 			url += "freeToPlay=" + freeToPlay + "&";
 		}
@@ -45,12 +46,12 @@ final class ChampionApi {
 		return championList;
 	}
 
-	public static ChampionList getChampions(String endpoint, String region, String key) throws RiotApiException {
-		return getChampions(endpoint, region, key, false);
+	public static ChampionList getChampions(Region region, String key) throws RiotApiException {
+		return getChampions(region, key, false);
 	}
 
-	public static Champion getChampionById(String endpoint, String region, String key, int champId) throws RiotApiException {
-		String url = endpoint + region + VERSION + "champion/" + champId + "?api_key=" + key;
+	public static Champion getChampionById(Region region, String key, int champId) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "champion/" + champId + "?api_key=" + key;
 
 		Champion champion = null;
 		try {

--- a/src/main/java/riotapi/CurrentGameApi.java
+++ b/src/main/java/riotapi/CurrentGameApi.java
@@ -27,7 +27,7 @@ final class CurrentGameApi {
 
 	private static final String endpoint = ".api.pvp.net/observer-mode/rest/consumer/getSpectatorGameInfo/";
 
-	public static CurrentGameInfo getCurrentGameInfo(PlatformId platformId, String key, long summonerId) throws RiotApiException {
+	public static CurrentGameInfo getCurrentGameInfo(PlatformId platformId, String key, String summonerId) throws RiotApiException {
 		String url = "https://" + platformId.getName() + endpoint + platformId.getId() + "/" + summonerId + "?api_key=" + key;
 
 		CurrentGameInfo currentGameInfo = null;
@@ -41,5 +41,9 @@ final class CurrentGameApi {
 		}
 
 		return currentGameInfo;
+	}
+
+	public static CurrentGameInfo getCurrentGameInfo(PlatformId platformId, String key, long summonerId) throws RiotApiException {
+		return getCurrentGameInfo(platformId, key, String.valueOf(summonerId));
 	}
 }

--- a/src/main/java/riotapi/FeaturedGamesApi.java
+++ b/src/main/java/riotapi/FeaturedGamesApi.java
@@ -18,6 +18,7 @@ package main.java.riotapi;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
+import constant.Region;
 import dto.FeaturedGames.FeaturedGames;
 
 final class FeaturedGamesApi {
@@ -26,7 +27,7 @@ final class FeaturedGamesApi {
 
 	private static final String endpoint = ".api.pvp.net/observer-mode/rest/featured";
 
-	public static FeaturedGames getFeaturedGames(String region, String key) throws RiotApiException {
+	public static FeaturedGames getFeaturedGames(Region region, String key) throws RiotApiException {
 		String url = "https://" + region + endpoint + "?api_key=" + key;
 
 		FeaturedGames featuredGames = null;

--- a/src/main/java/riotapi/GameApi.java
+++ b/src/main/java/riotapi/GameApi.java
@@ -24,7 +24,7 @@ final class GameApi {
 
 	private static final String VERSION = "/v1.3/";
 
-	public static RecentGames getRecentGames(String endpoint, String region, String key, long summonerId) throws RiotApiException {
+	public static RecentGames getRecentGames(String endpoint, String region, String key, String summonerId) throws RiotApiException {
 		String url = endpoint + region + VERSION + "game/by-summoner/" + summonerId + "/recent?api_key=" + key;
 
 		RecentGames recentGames = null;
@@ -38,5 +38,9 @@ final class GameApi {
 		}
 
 		return recentGames;
+	}
+
+	public static RecentGames getRecentGames(String endpoint, String region, String key, long summonerId) throws RiotApiException {
+		return getRecentGames(endpoint, region, key, String.valueOf(summonerId));
 	}
 }

--- a/src/main/java/riotapi/GameApi.java
+++ b/src/main/java/riotapi/GameApi.java
@@ -18,14 +18,15 @@ package main.java.riotapi;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
+import constant.Region;
 import dto.Game.RecentGames;
 
 final class GameApi {
 
 	private static final String VERSION = "/v1.3/";
 
-	public static RecentGames getRecentGames(String endpoint, String region, String key, String summonerId) throws RiotApiException {
-		String url = endpoint + region + VERSION + "game/by-summoner/" + summonerId + "/recent?api_key=" + key;
+	public static RecentGames getRecentGames(Region region, String key, String summonerId) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "game/by-summoner/" + summonerId + "/recent?api_key=" + key;
 
 		RecentGames recentGames = null;
 		try {
@@ -40,7 +41,7 @@ final class GameApi {
 		return recentGames;
 	}
 
-	public static RecentGames getRecentGames(String endpoint, String region, String key, long summonerId) throws RiotApiException {
-		return getRecentGames(endpoint, region, key, String.valueOf(summonerId));
+	public static RecentGames getRecentGames(Region region, String key, long summonerId) throws RiotApiException {
+		return getRecentGames(region, key, String.valueOf(summonerId));
 	}
 }

--- a/src/main/java/riotapi/LeagueApi.java
+++ b/src/main/java/riotapi/LeagueApi.java
@@ -25,14 +25,15 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
 import constant.QueueType;
+import constant.Region;
 import dto.League.League;
 
 final class LeagueApi {
 
 	private static final String VERSION = "/v2.5/";
 
-	public static Map<String, List<League>> getLeagueBySummoners(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/by-summoner/" + summonerIds + "?api_key=" + key;
+	public static Map<String, List<League>> getLeagueBySummoners(Region region, String key, String summonerIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "league/by-summoner/" + summonerIds + "?api_key=" + key;
 
 		Map<String, List<League>> leagues = null;
 		try {
@@ -48,12 +49,12 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static Map<String, List<League>> getLeagueBySummoners(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getLeagueBySummoners(endpoint, region, key, Convert.longToString(summonerIds));
+	public static Map<String, List<League>> getLeagueBySummoners(Region region, String key, long... summonerIds) throws RiotApiException {
+		return getLeagueBySummoners(region, key, Convert.longToString(summonerIds));
 	}
 
-	public static Map<String, List<League>> getLeagueEntryBySummoners(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/by-summoner/" + summonerIds + "/entry?api_key=" + key;
+	public static Map<String, List<League>> getLeagueEntryBySummoners(Region region, String key, String summonerIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "league/by-summoner/" + summonerIds + "/entry?api_key=" + key;
 
 		Map<String, List<League>> leagues = null;
 		try {
@@ -69,12 +70,12 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static Map<String, List<League>> getLeagueEntryBySummoners(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getLeagueEntryBySummoners(endpoint, region, key, Convert.longToString(summonerIds));
+	public static Map<String, List<League>> getLeagueEntryBySummoners(Region region, String key, long... summonerIds) throws RiotApiException {
+		return getLeagueEntryBySummoners(region, key, Convert.longToString(summonerIds));
 	}
 
-	public static Map<String, List<League>> getLeagueByTeams(String endpoint, String region, String key, String teamIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/by-team/" + teamIds + "?api_key=" + key;
+	public static Map<String, List<League>> getLeagueByTeams(Region region, String key, String teamIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "league/by-team/" + teamIds + "?api_key=" + key;
 
 		Map<String, List<League>> leagues = null;
 		try {
@@ -90,12 +91,12 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static Map<String, List<League>> getLeagueByTeams(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
-		return getLeagueByTeams(endpoint, region, key, Convert.longToString(teamIds));
+	public static Map<String, List<League>> getLeagueByTeams(Region region, String key, long... teamIds) throws RiotApiException {
+		return getLeagueByTeams(region, key, Convert.longToString(teamIds));
 	}
 
-	public static Map<String, List<League>> getLeagueEntryByTeams(String endpoint, String region, String key, String teamIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/by-team/" + teamIds + "/entry?api_key=" + key;
+	public static Map<String, List<League>> getLeagueEntryByTeams(Region region, String key, String teamIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "league/by-team/" + teamIds + "/entry?api_key=" + key;
 
 		Map<String, List<League>> leagues = null;
 		try {
@@ -111,12 +112,12 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static Map<String, List<League>> getLeagueEntryByTeams(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
-		return getLeagueEntryByTeams(endpoint, region, key, Convert.longToString(teamIds));
+	public static Map<String, List<League>> getLeagueEntryByTeams(Region region, String key, long... teamIds) throws RiotApiException {
+		return getLeagueEntryByTeams(region, key, Convert.longToString(teamIds));
 	}
 
-	public static League getChallengerLeague(String endpoint, String region, String key, QueueType queueType) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/challenger/?";
+	public static League getChallengerLeague(Region region, String key, QueueType queueType) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "league/challenger/?";
 		if (queueType != null) {
 			url += "type=" + queueType.name() + "&";
 		}
@@ -135,12 +136,12 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static League getChallengerLeague(String endpoint, String region, String key) throws RiotApiException {
-		return getChallengerLeague(endpoint, region, key, null);
+	public static League getChallengerLeague(Region region, String key) throws RiotApiException {
+		return getChallengerLeague(region, key, null);
 	}
 
-	public static League getMasterLeague(String endpoint, String region, String key, QueueType queueType) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/master/?";
+	public static League getMasterLeague(Region region, String key, QueueType queueType) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "league/master/?";
 		if (queueType != null) {
 			url += "type=" + queueType.name() + "&";
 		}
@@ -159,7 +160,7 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static League getMasterLeague(String endpoint, String region, String key) throws RiotApiException {
-		return getMasterLeague(endpoint, region, key, null);
+	public static League getMasterLeague(Region region, String key) throws RiotApiException {
+		return getMasterLeague(region, key, null);
 	}
 }

--- a/src/main/java/riotapi/LeagueApi.java
+++ b/src/main/java/riotapi/LeagueApi.java
@@ -31,14 +31,6 @@ final class LeagueApi {
 
 	private static final String VERSION = "/v2.5/";
 
-	public static Map<String, List<League>> getLeagueBySummoners(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getLeagueBySummoners(endpoint, region, key, Convert.longToString(summonerIds));
-	}
-
-	public static Map<String, List<League>> getLeagueEntryBySummoners(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getLeagueEntryBySummoners(endpoint, region, key, Convert.longToString(summonerIds));
-	}
-
 	public static Map<String, List<League>> getLeagueBySummoners(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
 		String url = endpoint + region + VERSION + "league/by-summoner/" + summonerIds + "?api_key=" + key;
 
@@ -54,6 +46,10 @@ final class LeagueApi {
 		}
 
 		return leagues;
+	}
+
+	public static Map<String, List<League>> getLeagueBySummoners(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
+		return getLeagueBySummoners(endpoint, region, key, Convert.longToString(summonerIds));
 	}
 
 	public static Map<String, List<League>> getLeagueEntryBySummoners(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
@@ -73,12 +69,8 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static Map<String, List<League>> getLeagueByTeams(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
-		return getLeagueByTeams(endpoint, region, key, Convert.longToString(teamIds));
-	}
-
-	public static Map<String, List<League>> getLeagueEntryByTeams(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
-		return getLeagueEntryByTeams(endpoint, region, key, Convert.longToString(teamIds));
+	public static Map<String, List<League>> getLeagueEntryBySummoners(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
+		return getLeagueEntryBySummoners(endpoint, region, key, Convert.longToString(summonerIds));
 	}
 
 	public static Map<String, List<League>> getLeagueByTeams(String endpoint, String region, String key, String teamIds) throws RiotApiException {
@@ -98,6 +90,10 @@ final class LeagueApi {
 		return leagues;
 	}
 
+	public static Map<String, List<League>> getLeagueByTeams(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
+		return getLeagueByTeams(endpoint, region, key, Convert.longToString(teamIds));
+	}
+
 	public static Map<String, List<League>> getLeagueEntryByTeams(String endpoint, String region, String key, String teamIds) throws RiotApiException {
 		String url = endpoint + region + VERSION + "league/by-team/" + teamIds + "/entry?api_key=" + key;
 
@@ -115,8 +111,16 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static League getChallengerLeague(String endpoint, String region, String key) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/challenger/?type=RANKED_SOLO_5x5&api_key=" + key;
+	public static Map<String, List<League>> getLeagueEntryByTeams(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
+		return getLeagueEntryByTeams(endpoint, region, key, Convert.longToString(teamIds));
+	}
+
+	public static League getChallengerLeague(String endpoint, String region, String key, QueueType queueType) throws RiotApiException {
+		String url = endpoint + region + VERSION + "league/challenger/?";
+		if (queueType != null) {
+			url += "type=" + queueType.name() + "&";
+		}
+		url += "api_key=" + key;
 
 		League leagues = null;
 		try {
@@ -131,8 +135,16 @@ final class LeagueApi {
 		return leagues;
 	}
 
-	public static League getChallengerLeague(String endpoint, String region, String key, QueueType queueType) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/challenger/?type=" + queueType.name() + "&api_key=" + key;
+	public static League getChallengerLeague(String endpoint, String region, String key) throws RiotApiException {
+		return getChallengerLeague(endpoint, region, key, null);
+	}
+
+	public static League getMasterLeague(String endpoint, String region, String key, QueueType queueType) throws RiotApiException {
+		String url = endpoint + region + VERSION + "league/master/?";
+		if (queueType != null) {
+			url += "type=" + queueType.name() + "&";
+		}
+		url += "api_key=" + key;
 
 		League leagues = null;
 		try {
@@ -148,34 +160,6 @@ final class LeagueApi {
 	}
 
 	public static League getMasterLeague(String endpoint, String region, String key) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/master/?type=RANKED_SOLO_5x5&api_key=" + key;
-
-		League leagues = null;
-		try {
-			leagues = new Gson().fromJson(Request.execute(url), League.class);
-		} catch (JsonSyntaxException e) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-		if (leagues == null) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-
-		return leagues;
-	}
-
-	public static League getMasterLeague(String endpoint, String region, String key, QueueType queueType) throws RiotApiException {
-		String url = endpoint + region + VERSION + "league/master/?type=" + queueType.name() + "&api_key=" + key;
-
-		League leagues = null;
-		try {
-			leagues = new Gson().fromJson(Request.execute(url), League.class);
-		} catch (JsonSyntaxException e) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-		if (leagues == null) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-
-		return leagues;
+		return getMasterLeague(endpoint, region, key, null);
 	}
 }

--- a/src/main/java/riotapi/MatchApi.java
+++ b/src/main/java/riotapi/MatchApi.java
@@ -18,14 +18,15 @@ package main.java.riotapi;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
+import constant.Region;
 import dto.Match.MatchDetail;
 
 final class MatchApi {
 
 	private static final String VERSION = "/v2.2/";
 
-	public static MatchDetail getMatch(String endpoint, String region, String key, long matchId, boolean includeTimeline) throws RiotApiException {
-		String url = endpoint + region + VERSION + "match/" + matchId + "?";
+	public static MatchDetail getMatch(Region region, String key, long matchId, boolean includeTimeline) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "match/" + matchId + "?";
 		if (!includeTimeline) {
 			url += "includeTimeline=" + includeTimeline + "&";
 		}
@@ -44,7 +45,7 @@ final class MatchApi {
 		return matchDetail;
 	}
 
-	public static MatchDetail getMatch(String endpoint, String region, String key, long matchId) throws RiotApiException {
-		return getMatch(endpoint, region, key, matchId, false);
+	public static MatchDetail getMatch(Region region, String key, long matchId) throws RiotApiException {
+		return getMatch(region, key, matchId, false);
 	}
 }

--- a/src/main/java/riotapi/MatchApi.java
+++ b/src/main/java/riotapi/MatchApi.java
@@ -25,7 +25,11 @@ final class MatchApi {
 	private static final String VERSION = "/v2.2/";
 
 	public static MatchDetail getMatch(String endpoint, String region, String key, long matchId, boolean includeTimeline) throws RiotApiException {
-		String url = endpoint + region + VERSION + "match/" + matchId + "?includeTimeline=" + includeTimeline + "&api_key=" + key;
+		String url = endpoint + region + VERSION + "match/" + matchId + "?";
+		if (!includeTimeline) {
+			url += "includeTimeline=" + includeTimeline + "&";
+		}
+		url += "api_key=" + key;
 
 		MatchDetail matchDetail = null;
 		try {
@@ -41,18 +45,6 @@ final class MatchApi {
 	}
 
 	public static MatchDetail getMatch(String endpoint, String region, String key, long matchId) throws RiotApiException {
-		String url = endpoint + region + VERSION + "match/" + matchId + "?api_key=" + key;
-
-		MatchDetail matchDetail = null;
-		try {
-			matchDetail = new Gson().fromJson(Request.execute(url), MatchDetail.class);
-		} catch (JsonSyntaxException e) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-		if (matchDetail == null) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-
-		return matchDetail;
+		return getMatch(endpoint, region, key, matchId, false);
 	}
 }

--- a/src/main/java/riotapi/MatchListApi.java
+++ b/src/main/java/riotapi/MatchListApi.java
@@ -18,15 +18,16 @@ package main.java.riotapi;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
+import constant.Region;
 import dto.MatchList.MatchList;
 
 final class MatchListApi {
 
 	private static final String VERSION = "/v2.2/";
 
-	public static MatchList getMatchList(String endpoint, String region, String key, long summonerId, String championIds, String rankedQueues, String seasons,
-			long beginTime, long endTime, int beginIndex, int endIndex) throws RiotApiException {
-		String url = endpoint + region + VERSION + "matchlist/by-summoner/" + summonerId + "?";
+	public static MatchList getMatchList(Region region, String key, long summonerId, String championIds, String rankedQueues, String seasons, long beginTime,
+			long endTime, int beginIndex, int endIndex) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "matchlist/by-summoner/" + summonerId + "?";
 		if (championIds != null) {
 			url += "championIds=" + championIds + "&";
 		}

--- a/src/main/java/riotapi/Request.java
+++ b/src/main/java/riotapi/Request.java
@@ -11,42 +11,42 @@ import java.util.logging.Logger;
 
 public class Request {
 
-    public static String execute(String URL) throws RiotApiException {
+	public static String execute(String URL) throws RiotApiException {
 
-        HttpURLConnection connection = null;
+		HttpURLConnection connection = null;
 
-        try {
-            String requestURL = URL;
-            URL url = new URL(requestURL);
+		try {
+			String requestURL = URL;
+			URL url = new URL(requestURL);
 
-            connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-            connection.setInstanceFollowRedirects(false);
+			connection = (HttpURLConnection) url.openConnection();
+			connection.setRequestMethod("GET");
+			connection.setInstanceFollowRedirects(false);
 
-            int responseCode = connection.getResponseCode();
-            if (responseCode != 200) {
-                throw new RiotApiException(responseCode);
-            }
+			int responseCode = connection.getResponseCode();
+			if (responseCode != 200) {
+				throw new RiotApiException(responseCode);
+			}
 
-            InputStream is = connection.getInputStream();
-            BufferedReader rd = new BufferedReader(new InputStreamReader(is, "utf-8"));
-            StringBuilder response = new StringBuilder();
+			InputStream is = connection.getInputStream();
+			BufferedReader rd = new BufferedReader(new InputStreamReader(is, "utf-8"));
+			StringBuilder response = new StringBuilder();
 
-            String line;
-            while ((line = rd.readLine()) != null) {
-                response.append(line);
-                response.append('\r');
-            }
+			String line;
+			while ((line = rd.readLine()) != null) {
+				response.append(line);
+				response.append('\r');
+			}
 
-            connection.disconnect();
-            return response.toString();
-        } catch (IOException ex) {
-            Logger.getLogger(Request.class.getName()).log(Level.SEVERE, null, ex);
-            throw new RiotApiException(RiotApiException.IOEXCEPTION);
-        } finally {
-            if(connection != null){
-                connection.disconnect();
-            }
-        }
-    }
+			connection.disconnect();
+			return response.toString();
+		} catch (IOException ex) {
+			Logger.getLogger(Request.class.getName()).log(Level.SEVERE, null, ex);
+			throw new RiotApiException(RiotApiException.IOEXCEPTION);
+		} finally {
+			if (connection != null) {
+				connection.disconnect();
+			}
+		}
+	}
 }

--- a/src/main/java/riotapi/RiotApi.java
+++ b/src/main/java/riotapi/RiotApi.java
@@ -66,11 +66,8 @@ import dto.Team.Team;
  */
 public class RiotApi {
 
-	// The base URL for all API requests
-	private String endpoint = Region.GLOBAL.getEndpoint();
-
 	private Region region = Region.NA; // North American region default
-	private Season season = Season.CURRENT; // Current season default
+	private Season season = null;
 	private String key;
 
 	public RiotApi() {

--- a/src/main/java/riotapi/RiotApi.java
+++ b/src/main/java/riotapi/RiotApi.java
@@ -30,14 +30,13 @@ import constant.staticdata.MasteryListData;
 import constant.staticdata.RuneData;
 import constant.staticdata.RuneListData;
 import constant.staticdata.SpellData;
-import dto.Champion.*;
+import dto.Champion.Champion;
 import dto.CurrentGame.CurrentGameInfo;
 import dto.FeaturedGames.FeaturedGames;
 import dto.Game.RecentGames;
 import dto.League.League;
 import dto.Match.MatchDetail;
 import dto.MatchList.MatchList;
-import dto.Team.Team;
 import dto.Static.ChampionList;
 import dto.Static.GameMapList;
 import dto.Static.Item;
@@ -57,6 +56,7 @@ import dto.Status.ShardStatus;
 import dto.Summoner.MasteryPages;
 import dto.Summoner.RunePages;
 import dto.Summoner.Summoner;
+import dto.Team.Team;
 
 /**
  * Riot Games API Java Library - riot-api-java
@@ -99,7 +99,7 @@ public class RiotApi {
 	 */
 	public dto.Champion.ChampionList getChampions() throws RiotApiException {
 
-		return ChampionApi.getChampions(getEndpoint(), getRegion(), getKey());
+		return ChampionApi.getChampions(getRegion(), getKey());
 	}
 
 	/**
@@ -114,7 +114,7 @@ public class RiotApi {
 	 */
 	public dto.Champion.ChampionList getChampions(Region region) throws RiotApiException {
 
-		return ChampionApi.getChampions(region.getEndpoint(), region.getName(), getKey());
+		return ChampionApi.getChampions(region, getKey());
 	}
 
 	/**
@@ -129,7 +129,7 @@ public class RiotApi {
 	 */
 	public dto.Champion.ChampionList getChampions(boolean freeToPlay) throws RiotApiException {
 
-		return ChampionApi.getChampions(getEndpoint(), getRegion(), getKey(), freeToPlay);
+		return ChampionApi.getChampions(getRegion(), getKey(), freeToPlay);
 	}
 
 	/**
@@ -146,7 +146,7 @@ public class RiotApi {
 	 */
 	public dto.Champion.ChampionList getChampions(Region region, boolean freeToPlay) throws RiotApiException {
 
-		return ChampionApi.getChampions(region.getEndpoint(), region.getName(), getKey(), freeToPlay);
+		return ChampionApi.getChampions(region, getKey(), freeToPlay);
 	}
 
 	/**
@@ -161,7 +161,7 @@ public class RiotApi {
 	 */
 	public dto.Champion.ChampionList getFreeToPlayChampions(Region region) throws RiotApiException {
 
-		return ChampionApi.getChampions(region.getEndpoint(), region.getName(), getKey(), true);
+		return ChampionApi.getChampions(region, getKey(), true);
 	}
 
 	/**
@@ -174,7 +174,7 @@ public class RiotApi {
 	 */
 	public dto.Champion.ChampionList getFreeToPlayChampions() throws RiotApiException {
 
-		return ChampionApi.getChampions(getEndpoint(), getRegion(), getKey(), true);
+		return ChampionApi.getChampions(getRegion(), getKey(), true);
 	}
 
 	/**
@@ -191,7 +191,7 @@ public class RiotApi {
 	 */
 	public Champion getChampionById(Region region, int champId) throws RiotApiException {
 
-		return ChampionApi.getChampionById(region.getEndpoint(), region.getName(), getKey(), champId);
+		return ChampionApi.getChampionById(region, getKey(), champId);
 	}
 
 	/**
@@ -206,7 +206,7 @@ public class RiotApi {
 	 */
 	public Champion getChampionById(int champId) throws RiotApiException {
 
-		return ChampionApi.getChampionById(getEndpoint(), getRegion(), getKey(), champId);
+		return ChampionApi.getChampionById(getRegion(), getKey(), champId);
 	}
 
 	/**
@@ -223,7 +223,7 @@ public class RiotApi {
 	 */
 	public RecentGames getRecentGames(Region region, long summonerId) throws RiotApiException {
 
-		return GameApi.getRecentGames(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		return GameApi.getRecentGames(region, getKey(), summonerId);
 	}
 
 	/**
@@ -238,7 +238,7 @@ public class RiotApi {
 	 */
 	public RecentGames getRecentGames(long summonerId) throws RiotApiException {
 
-		return GameApi.getRecentGames(getEndpoint(), getRegion(), getKey(), summonerId);
+		return GameApi.getRecentGames(getRegion(), getKey(), summonerId);
 	}
 
 	/**
@@ -255,7 +255,7 @@ public class RiotApi {
 	 */
 	public RecentGames getRecentGames(Region region, String summonerId) throws RiotApiException {
 
-		return GameApi.getRecentGames(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		return GameApi.getRecentGames(region, getKey(), summonerId);
 	}
 
 	/**
@@ -270,7 +270,7 @@ public class RiotApi {
 	 */
 	public RecentGames getRecentGames(String summonerId) throws RiotApiException {
 
-		return GameApi.getRecentGames(getEndpoint(), getRegion(), getKey(), summonerId);
+		return GameApi.getRecentGames(getRegion(), getKey(), summonerId);
 	}
 
 	/**
@@ -287,7 +287,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueBySummoner(Region region, long summonerId) throws RiotApiException {
 
-		return LeagueApi.getLeagueBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+		return LeagueApi.getLeagueBySummoners(region, getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -302,7 +302,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueBySummoner(long summonerId) throws RiotApiException {
 
-		return LeagueApi.getLeagueBySummoners(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+		return LeagueApi.getLeagueBySummoners(getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -319,7 +319,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueBySummoner(Region region, String summonerId) throws RiotApiException {
 
-		return LeagueApi.getLeagueBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerId).get(summonerId);
+		return LeagueApi.getLeagueBySummoners(region, getKey(), summonerId).get(summonerId);
 	}
 
 	/**
@@ -333,7 +333,7 @@ public class RiotApi {
 	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueBySummoner(String summonerId) throws RiotApiException {
-		return LeagueApi.getLeagueBySummoners(getEndpoint(), getRegion(), getKey(), summonerId).get(summonerId);
+		return LeagueApi.getLeagueBySummoners(getRegion(), getKey(), summonerId).get(summonerId);
 	}
 
 	/**
@@ -350,7 +350,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueBySummoners(Region region, long... summonerIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return LeagueApi.getLeagueBySummoners(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -365,7 +365,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueBySummoners(long... summonerIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return LeagueApi.getLeagueBySummoners(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -382,7 +382,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueBySummoners(Region region, String summonerIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return LeagueApi.getLeagueBySummoners(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -396,7 +396,7 @@ public class RiotApi {
 	 *             if the API returns an error or unparsable result
 	 */
 	public Map<String, List<League>> getLeagueBySummoners(String summonerIds) throws RiotApiException {
-		return LeagueApi.getLeagueBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return LeagueApi.getLeagueBySummoners(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -413,7 +413,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueEntryBySummoner(Region region, long summonerId) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+		return LeagueApi.getLeagueEntryBySummoners(region, getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -428,7 +428,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueEntryBySummoner(long summonerId) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryBySummoners(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+		return LeagueApi.getLeagueEntryBySummoners(getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -445,7 +445,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueEntryBySummoner(Region region, String summonerId) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerId).get(summonerId);
+		return LeagueApi.getLeagueEntryBySummoners(region, getKey(), summonerId).get(summonerId);
 	}
 
 	/**
@@ -460,7 +460,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueEntryBySummoner(String summonerId) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryBySummoners(getEndpoint(), getRegion(), getKey(), summonerId).get(summonerId);
+		return LeagueApi.getLeagueEntryBySummoners(getRegion(), getKey(), summonerId).get(summonerId);
 	}
 
 	/**
@@ -477,7 +477,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueEntryBySummoners(Region region, long... summonerIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return LeagueApi.getLeagueEntryBySummoners(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -492,7 +492,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueEntryBySummoners(long... summonerIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return LeagueApi.getLeagueEntryBySummoners(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -509,7 +509,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueEntryBySummoners(Region region, String summonerIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return LeagueApi.getLeagueEntryBySummoners(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -524,7 +524,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueEntryBySummoners(String summonerIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return LeagueApi.getLeagueEntryBySummoners(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -541,7 +541,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueByTeam(Region region, String teamId) throws RiotApiException {
 
-		return LeagueApi.getLeagueByTeams(region.getEndpoint(), region.getName(), getKey(), teamId).get(teamId);
+		return LeagueApi.getLeagueByTeams(region, getKey(), teamId).get(teamId);
 	}
 
 	/**
@@ -556,7 +556,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueByTeam(String teamId) throws RiotApiException {
 
-		return LeagueApi.getLeagueByTeams(getEndpoint(), getRegion(), getKey(), teamId).get(teamId);
+		return LeagueApi.getLeagueByTeams(getRegion(), getKey(), teamId).get(teamId);
 	}
 
 	/**
@@ -573,7 +573,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueByTeams(Region region, String teamIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueByTeams(region.getEndpoint(), region.getName(), getKey(), teamIds);
+		return LeagueApi.getLeagueByTeams(region, getKey(), teamIds);
 	}
 
 	/**
@@ -588,7 +588,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueByTeams(String teamIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueByTeams(getEndpoint(), getRegion(), getKey(), teamIds);
+		return LeagueApi.getLeagueByTeams(getRegion(), getKey(), teamIds);
 	}
 
 	/**
@@ -605,7 +605,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueEntryByTeam(Region region, String teamId) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryByTeams(region.getEndpoint(), region.getName(), getKey(), teamId).get(teamId);
+		return LeagueApi.getLeagueEntryByTeams(region, getKey(), teamId).get(teamId);
 	}
 
 	/**
@@ -620,7 +620,7 @@ public class RiotApi {
 	 */
 	public List<League> getLeagueEntryByTeam(String teamId) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryByTeams(getEndpoint(), getRegion(), getKey(), teamId).get(teamId);
+		return LeagueApi.getLeagueEntryByTeams(getRegion(), getKey(), teamId).get(teamId);
 	}
 
 	/**
@@ -637,7 +637,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueEntryByTeams(Region region, String teamIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryByTeams(region.getEndpoint(), region.getName(), getKey(), teamIds);
+		return LeagueApi.getLeagueEntryByTeams(region, getKey(), teamIds);
 	}
 
 	/**
@@ -652,7 +652,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<League>> getLeagueEntryByTeams(String teamIds) throws RiotApiException {
 
-		return LeagueApi.getLeagueEntryByTeams(getEndpoint(), getRegion(), getKey(), teamIds);
+		return LeagueApi.getLeagueEntryByTeams(getRegion(), getKey(), teamIds);
 	}
 
 	/**
@@ -667,7 +667,7 @@ public class RiotApi {
 	 */
 	public League getChallengerLeague(Region region) throws RiotApiException {
 
-		return LeagueApi.getChallengerLeague(region.getEndpoint(), region.getName(), getKey());
+		return LeagueApi.getChallengerLeague(region, getKey());
 	}
 
 	/**
@@ -680,7 +680,7 @@ public class RiotApi {
 	 */
 	public League getChallengerLeague() throws RiotApiException {
 
-		return LeagueApi.getChallengerLeague(getEndpoint(), getRegion(), getKey());
+		return LeagueApi.getChallengerLeague(getRegion(), getKey());
 	}
 
 	/**
@@ -697,7 +697,7 @@ public class RiotApi {
 	 */
 	public League getChallengerLeague(Region region, QueueType queueType) throws RiotApiException {
 
-		return LeagueApi.getChallengerLeague(region.getEndpoint(), region.getName(), getKey(), queueType);
+		return LeagueApi.getChallengerLeague(region, getKey(), queueType);
 	}
 
 	/**
@@ -712,7 +712,7 @@ public class RiotApi {
 	 */
 	public League getChallengerLeague(QueueType queueType) throws RiotApiException {
 
-		return LeagueApi.getChallengerLeague(getEndpoint(), getRegion(), getKey(), queueType);
+		return LeagueApi.getChallengerLeague(getRegion(), getKey(), queueType);
 	}
 
 	/**
@@ -727,7 +727,7 @@ public class RiotApi {
 	 */
 	public League getMasterLeague(Region region) throws RiotApiException {
 
-		return LeagueApi.getMasterLeague(region.getEndpoint(), region.getName(), getKey());
+		return LeagueApi.getMasterLeague(region, getKey());
 	}
 
 	/**
@@ -740,7 +740,7 @@ public class RiotApi {
 	 */
 	public League getMasterLeague() throws RiotApiException {
 
-		return LeagueApi.getMasterLeague(getEndpoint(), getRegion(), getKey());
+		return LeagueApi.getMasterLeague(getRegion(), getKey());
 	}
 
 	/**
@@ -757,7 +757,7 @@ public class RiotApi {
 	 */
 	public League getMasterLeague(Region region, QueueType queueType) throws RiotApiException {
 
-		return LeagueApi.getMasterLeague(region.getEndpoint(), region.getName(), getKey(), queueType);
+		return LeagueApi.getMasterLeague(region, getKey(), queueType);
 	}
 
 	/**
@@ -772,7 +772,7 @@ public class RiotApi {
 	 */
 	public League getMasterLeague(QueueType queueType) throws RiotApiException {
 
-		return LeagueApi.getMasterLeague(getEndpoint(), getRegion(), getKey(), queueType);
+		return LeagueApi.getMasterLeague(getRegion(), getKey(), queueType);
 	}
 
 	/**
@@ -791,7 +791,7 @@ public class RiotApi {
 	 */
 	public PlayerStatsSummaryList getPlayerStatsSummary(Region region, Season season, long summonerId) throws RiotApiException {
 
-		return StatsApi.getPlayerStatsSummary(region.getEndpoint(), region.getName(), season.getName(), getKey(), summonerId);
+		return StatsApi.getPlayerStatsSummary(region, season, getKey(), summonerId);
 	}
 
 	/**
@@ -808,7 +808,7 @@ public class RiotApi {
 	 */
 	public PlayerStatsSummaryList getPlayerStatsSummary(Season season, long summonerId) throws RiotApiException {
 
-		return StatsApi.getPlayerStatsSummary(getEndpoint(), getRegion(), season.getName(), getKey(), summonerId);
+		return StatsApi.getPlayerStatsSummary(getRegion(), season, getKey(), summonerId);
 	}
 
 	/**
@@ -825,7 +825,7 @@ public class RiotApi {
 	 */
 	public PlayerStatsSummaryList getPlayerStatsSummary(Region region, long summonerId) throws RiotApiException {
 
-		return StatsApi.getPlayerStatsSummary(region.getEndpoint(), region.getName(), getSeason(), getKey(), summonerId);
+		return StatsApi.getPlayerStatsSummary(region, getSeason(), getKey(), summonerId);
 	}
 
 	/**
@@ -840,7 +840,7 @@ public class RiotApi {
 	 */
 	public PlayerStatsSummaryList getPlayerStatsSummary(long summonerId) throws RiotApiException {
 
-		return StatsApi.getPlayerStatsSummary(getEndpoint(), getRegion(), getSeason(), getKey(), summonerId);
+		return StatsApi.getPlayerStatsSummary(getRegion(), getSeason(), getKey(), summonerId);
 	}
 
 	/**
@@ -859,7 +859,7 @@ public class RiotApi {
 	 */
 	public RankedStats getRankedStats(Region region, Season season, long summonerId) throws RiotApiException {
 
-		return StatsApi.getRankedStats(region.getEndpoint(), region.getName(), season.getName(), getKey(), summonerId);
+		return StatsApi.getRankedStats(region, season, getKey(), summonerId);
 	}
 
 	/**
@@ -876,7 +876,7 @@ public class RiotApi {
 	 */
 	public RankedStats getRankedStats(Season season, long summonerId) throws RiotApiException {
 
-		return StatsApi.getRankedStats(getEndpoint(), getRegion(), season.getName(), getKey(), summonerId);
+		return StatsApi.getRankedStats(getRegion(), season, getKey(), summonerId);
 	}
 
 	/**
@@ -893,7 +893,7 @@ public class RiotApi {
 	 */
 	public RankedStats getRankedStats(Region region, long summonerId) throws RiotApiException {
 
-		return StatsApi.getRankedStats(region.getEndpoint(), region.getName(), getSeason(), getKey(), summonerId);
+		return StatsApi.getRankedStats(region, getSeason(), getKey(), summonerId);
 	}
 
 	/**
@@ -908,7 +908,7 @@ public class RiotApi {
 	 */
 	public RankedStats getRankedStats(long summonerId) throws RiotApiException {
 
-		return StatsApi.getRankedStats(getEndpoint(), getRegion(), getSeason(), getKey(), summonerId);
+		return StatsApi.getRankedStats(getRegion(), getSeason(), getKey(), summonerId);
 	}
 
 	/**
@@ -925,7 +925,7 @@ public class RiotApi {
 	 */
 	public MasteryPages getMasteryPages(Region region, long summonerId) throws RiotApiException {
 
-		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+		return SummonerApi.getMasteryPages(region, getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -940,7 +940,7 @@ public class RiotApi {
 	 */
 	public MasteryPages getMasteryPages(long summonerId) throws RiotApiException {
 
-		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+		return SummonerApi.getMasteryPages(getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -957,7 +957,7 @@ public class RiotApi {
 	 */
 	public Map<String, MasteryPages> getMasteryPages(Region region, String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getMasteryPages(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -972,7 +972,7 @@ public class RiotApi {
 	 */
 	public Map<String, MasteryPages> getMasteryPages(String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getMasteryPages(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -989,7 +989,7 @@ public class RiotApi {
 	 */
 	public Map<String, MasteryPages> getMasteryPages(Region region, long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getMasteryPages(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1004,7 +1004,7 @@ public class RiotApi {
 	 */
 	public Map<String, MasteryPages> getMasteryPages(long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getMasteryPages(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1021,7 +1021,7 @@ public class RiotApi {
 	 */
 	public RunePages getRunePages(Region region, long summonerId) throws RiotApiException {
 
-		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+		return SummonerApi.getRunePages(region, getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -1036,7 +1036,7 @@ public class RiotApi {
 	 */
 	public RunePages getRunePages(long summonerId) throws RiotApiException {
 
-		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+		return SummonerApi.getRunePages(getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -1053,7 +1053,7 @@ public class RiotApi {
 	 */
 	public Map<String, RunePages> getRunePages(Region region, String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getRunePages(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1068,7 +1068,7 @@ public class RiotApi {
 	 */
 	public Map<String, RunePages> getRunePages(String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getRunePages(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1085,7 +1085,7 @@ public class RiotApi {
 	 */
 	public Map<String, RunePages> getRunePages(Region region, long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getRunePages(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1100,7 +1100,7 @@ public class RiotApi {
 	 */
 	public Map<String, RunePages> getRunePages(long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getRunePages(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1117,7 +1117,7 @@ public class RiotApi {
 	 */
 	public Summoner getSummonerByName(Region region, String summonerName) throws RiotApiException {
 
-		Map<String, Summoner> summoners = SummonerApi.getSummonersByName(region.getEndpoint(), region.getName(), getKey(), summonerName);
+		Map<String, Summoner> summoners = SummonerApi.getSummonersByName(region, getKey(), summonerName);
 		Summoner summoner = summoners.entrySet().iterator().next().getValue();
 		return summoner;
 
@@ -1135,7 +1135,7 @@ public class RiotApi {
 	 */
 	public Summoner getSummonerByName(String summonerName) throws RiotApiException {
 
-		Map<String, Summoner> summoners = SummonerApi.getSummonersByName(getEndpoint(), getRegion(), getKey(), summonerName);
+		Map<String, Summoner> summoners = SummonerApi.getSummonersByName(getRegion(), getKey(), summonerName);
 		Summoner summoner = summoners.entrySet().iterator().next().getValue();
 		return summoner;
 	}
@@ -1155,7 +1155,7 @@ public class RiotApi {
 	 */
 	public Map<String, Summoner> getSummonersByName(Region region, String summonerNames) throws RiotApiException {
 
-		return SummonerApi.getSummonersByName(region.getEndpoint(), region.getName(), getKey(), summonerNames);
+		return SummonerApi.getSummonersByName(region, getKey(), summonerNames);
 	}
 
 	/**
@@ -1171,7 +1171,7 @@ public class RiotApi {
 	 */
 	public Map<String, Summoner> getSummonersByName(String summonerNames) throws RiotApiException {
 
-		return SummonerApi.getSummonersByName(getEndpoint(), getRegion(), getKey(), summonerNames);
+		return SummonerApi.getSummonersByName(getRegion(), getKey(), summonerNames);
 	}
 
 	/**
@@ -1188,7 +1188,7 @@ public class RiotApi {
 	 */
 	public Summoner getSummonerById(Region region, long summonerId) throws RiotApiException {
 
-		Map<String, Summoner> summoners = SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		Map<String, Summoner> summoners = SummonerApi.getSummonersById(region, getKey(), summonerId);
 		Summoner summoner = summoners.entrySet().iterator().next().getValue();
 		return summoner;
 	}
@@ -1205,7 +1205,7 @@ public class RiotApi {
 	 */
 	public Summoner getSummonerById(long summonerId) throws RiotApiException {
 
-		Map<String, Summoner> summoners = SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerId);
+		Map<String, Summoner> summoners = SummonerApi.getSummonersById(getRegion(), getKey(), summonerId);
 		Summoner summoner = summoners.entrySet().iterator().next().getValue();
 		return summoner;
 	}
@@ -1224,7 +1224,7 @@ public class RiotApi {
 	 */
 	public Summoner getSummonerById(Region region, String summonerId) throws RiotApiException {
 
-		Map<String, Summoner> summoners = SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		Map<String, Summoner> summoners = SummonerApi.getSummonersById(region, getKey(), summonerId);
 		Summoner summoner = summoners.entrySet().iterator().next().getValue();
 		return summoner;
 	}
@@ -1241,7 +1241,7 @@ public class RiotApi {
 	 */
 	public Summoner getSummonerById(String summonerId) throws RiotApiException {
 
-		Map<String, Summoner> summoners = SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerId);
+		Map<String, Summoner> summoners = SummonerApi.getSummonersById(getRegion(), getKey(), summonerId);
 		Summoner summoner = summoners.entrySet().iterator().next().getValue();
 		return summoner;
 	}
@@ -1260,7 +1260,7 @@ public class RiotApi {
 	 */
 	public Map<String, Summoner> getSummonersById(Region region, long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getSummonersById(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1275,7 +1275,7 @@ public class RiotApi {
 	 */
 	public Map<String, Summoner> getSummonersById(long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getSummonersById(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1292,7 +1292,7 @@ public class RiotApi {
 	 */
 	public Map<String, Summoner> getSummonersById(Region region, String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getSummonersById(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1307,7 +1307,7 @@ public class RiotApi {
 	 */
 	public Map<String, Summoner> getSummonersById(String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getSummonersById(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1323,7 +1323,7 @@ public class RiotApi {
 	 */
 	public String getSummonerName(Region region, long summonerId) throws RiotApiException {
 
-		Map<String, String> summoners = SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		Map<String, String> summoners = SummonerApi.getSummonerNames(region, getKey(), summonerId);
 		String name = summoners.entrySet().iterator().next().getValue();
 		return name;
 	}
@@ -1339,7 +1339,7 @@ public class RiotApi {
 	 */
 	public String getSummonerName(long summonerId) throws RiotApiException {
 
-		Map<String, String> summoners = SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerId);
+		Map<String, String> summoners = SummonerApi.getSummonerNames(getRegion(), getKey(), summonerId);
 		String name = summoners.entrySet().iterator().next().getValue();
 		return name;
 	}
@@ -1357,7 +1357,7 @@ public class RiotApi {
 	 */
 	public String getSummonerName(Region region, String summonerId) throws RiotApiException {
 
-		Map<String, String> summoners = SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		Map<String, String> summoners = SummonerApi.getSummonerNames(region, getKey(), summonerId);
 		String name = summoners.entrySet().iterator().next().getValue();
 		return name;
 	}
@@ -1373,7 +1373,7 @@ public class RiotApi {
 	 */
 	public String getSummonerName(String summonerId) throws RiotApiException {
 
-		Map<String, String> summoners = SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerId);
+		Map<String, String> summoners = SummonerApi.getSummonerNames(getRegion(), getKey(), summonerId);
 		String name = summoners.entrySet().iterator().next().getValue();
 		return name;
 	}
@@ -1391,7 +1391,7 @@ public class RiotApi {
 	 */
 	public Map<String, String> getSummonerNames(Region region, long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getSummonerNames(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1405,7 +1405,7 @@ public class RiotApi {
 	 */
 	public Map<String, String> getSummonerNames(long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getSummonerNames(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1421,7 +1421,7 @@ public class RiotApi {
 	 */
 	public Map<String, String> getSummonerNames(Region region, String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getSummonerNames(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1435,7 +1435,7 @@ public class RiotApi {
 	 */
 	public Map<String, String> getSummonerNames(String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getSummonerNames(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1452,7 +1452,7 @@ public class RiotApi {
 	 */
 	public List<Team> getTeamsBySummonerId(Region region, long summonerId) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+		return TeamApi.getTeamsBySummonerIds(region, getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -1467,7 +1467,7 @@ public class RiotApi {
 	 */
 	public List<Team> getTeamsBySummonerId(long summonerId) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+		return TeamApi.getTeamsBySummonerIds(getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
 	}
 
 	/**
@@ -1484,7 +1484,7 @@ public class RiotApi {
 	 */
 	public List<Team> getTeamsBySummonerId(Region region, String summonerId) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerId).get(summonerId);
+		return TeamApi.getTeamsBySummonerIds(region, getKey(), summonerId).get(summonerId);
 	}
 
 	/**
@@ -1499,7 +1499,7 @@ public class RiotApi {
 	 */
 	public List<Team> getTeamsBySummonerId(String summonerId) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerId).get(summonerId);
+		return TeamApi.getTeamsBySummonerIds(getRegion(), getKey(), summonerId).get(summonerId);
 	}
 
 	/**
@@ -1516,7 +1516,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<Team>> getTeamsBySummonerIds(Region region, long... summonerIds) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return TeamApi.getTeamsBySummonerIds(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1531,7 +1531,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<Team>> getTeamsBySummonerIds(long... summonerIds) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return TeamApi.getTeamsBySummonerIds(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1548,7 +1548,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<Team>> getTeamsBySummonerIds(Region region, String summonerIds) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return TeamApi.getTeamsBySummonerIds(region, getKey(), summonerIds);
 	}
 
 	/**
@@ -1563,7 +1563,7 @@ public class RiotApi {
 	 */
 	public Map<String, List<Team>> getTeamsBySummonerIds(String summonerIds) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return TeamApi.getTeamsBySummonerIds(getRegion(), getKey(), summonerIds);
 	}
 
 	/**
@@ -1580,7 +1580,7 @@ public class RiotApi {
 	 */
 	public MatchDetail getMatch(Region region, long matchId) throws RiotApiException {
 
-		return MatchApi.getMatch(region.getEndpoint(), region.getName(), getKey(), matchId);
+		return MatchApi.getMatch(region, getKey(), matchId);
 	}
 
 	/**
@@ -1595,7 +1595,7 @@ public class RiotApi {
 	 */
 	public MatchDetail getMatch(long matchId) throws RiotApiException {
 
-		return MatchApi.getMatch(getEndpoint(), getRegion(), getKey(), matchId);
+		return MatchApi.getMatch(getRegion(), getKey(), matchId);
 	}
 
 	/**
@@ -1614,7 +1614,7 @@ public class RiotApi {
 	 */
 	public MatchDetail getMatch(Region region, long matchId, boolean includeTimeline) throws RiotApiException {
 
-		return MatchApi.getMatch(region.getEndpoint(), region.getName(), getKey(), matchId, includeTimeline);
+		return MatchApi.getMatch(region, getKey(), matchId, includeTimeline);
 	}
 
 	/**
@@ -1631,7 +1631,7 @@ public class RiotApi {
 	 */
 	public MatchDetail getMatch(long matchId, boolean includeTimeline) throws RiotApiException {
 
-		return MatchApi.getMatch(getEndpoint(), getRegion(), getKey(), matchId, includeTimeline);
+		return MatchApi.getMatch(getRegion(), getKey(), matchId, includeTimeline);
 	}
 
 	/**
@@ -1663,8 +1663,7 @@ public class RiotApi {
 	public MatchList getMatchList(Region region, long summonerId, String championIds, String rankedQueues, String seasons, long beginTime, long endTime,
 			int beginIndex, int endIndex) throws RiotApiException {
 
-		return MatchListApi.getMatchList(region.getEndpoint(), region.getName(), getKey(), summonerId, championIds, rankedQueues, seasons, beginTime, endTime,
-				beginIndex, endIndex);
+		return MatchListApi.getMatchList(region, getKey(), summonerId, championIds, rankedQueues, seasons, beginTime, endTime, beginIndex, endIndex);
 	}
 
 	/**
@@ -1681,7 +1680,7 @@ public class RiotApi {
 	 */
 	public MatchList getMatchList(Region region, long summonerId) throws RiotApiException {
 
-		return MatchListApi.getMatchList(region.getEndpoint(), region.getName(), getKey(), summonerId, null, null, null, -1, -1, -1, -1);
+		return MatchListApi.getMatchList(region, getKey(), summonerId, null, null, null, -1, -1, -1, -1);
 	}
 
 	/**
@@ -1711,8 +1710,7 @@ public class RiotApi {
 	public MatchList getMatchList(long summonerId, String championIds, String rankedQueues, String seasons, long beginTime, long endTime, int beginIndex,
 			int endIndex) throws RiotApiException {
 
-		return MatchListApi.getMatchList(getEndpoint(), getRegion(), getKey(), summonerId, championIds, rankedQueues, seasons, beginTime, endTime, beginIndex,
-				endIndex);
+		return MatchListApi.getMatchList(getRegion(), getKey(), summonerId, championIds, rankedQueues, seasons, beginTime, endTime, beginIndex, endIndex);
 	}
 
 	/**
@@ -1727,7 +1725,7 @@ public class RiotApi {
 	 */
 	public MatchList getMatchList(long summonerId) throws RiotApiException {
 
-		return MatchListApi.getMatchList(getEndpoint(), getRegion(), getKey(), summonerId, null, null, null, -1, -1, -1, -1);
+		return MatchListApi.getMatchList(getRegion(), getKey(), summonerId, null, null, null, -1, -1, -1, -1);
 	}
 
 	/**
@@ -1776,7 +1774,7 @@ public class RiotApi {
 	 */
 	public FeaturedGames getFeaturedGames(Region region) throws RiotApiException {
 
-		return FeaturedGamesApi.getFeaturedGames(region.getName(), getKey());
+		return FeaturedGamesApi.getFeaturedGames(region, getKey());
 	}
 
 	/**
@@ -1815,7 +1813,7 @@ public class RiotApi {
 	 */
 	public ChampionList getDataChampionList(Region region, String locale, String version, boolean dataById, ChampData... champData) throws RiotApiException {
 
-		return StaticDataApi.getDataChampionList(region.getName(), getKey(), locale, version, dataById, champData);
+		return StaticDataApi.getDataChampionList(region, getKey(), locale, version, dataById, champData);
 	}
 
 	/**
@@ -1854,7 +1852,7 @@ public class RiotApi {
 	 */
 	public ChampionList getDataChampionList(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataChampionList(region.getName(), getKey(), null, null, false, (ChampData) null);
+		return StaticDataApi.getDataChampionList(region, getKey(), null, null, false, (ChampData) null);
 	}
 
 	/**
@@ -1892,7 +1890,7 @@ public class RiotApi {
 	 */
 	public dto.Static.Champion getDataChampion(Region region, int id, String locale, String version, ChampData... champData) throws RiotApiException {
 
-		return StaticDataApi.getDataChampion(region.getName(), getKey(), id, locale, version, champData);
+		return StaticDataApi.getDataChampion(region, getKey(), id, locale, version, champData);
 	}
 
 	/**
@@ -1932,7 +1930,7 @@ public class RiotApi {
 	 */
 	public dto.Static.Champion getDataChampion(Region region, int id) throws RiotApiException {
 
-		return StaticDataApi.getDataChampion(region.getName(), getKey(), id, null, null, (ChampData) null);
+		return StaticDataApi.getDataChampion(region, getKey(), id, null, null, (ChampData) null);
 	}
 
 	/**
@@ -1967,7 +1965,7 @@ public class RiotApi {
 	 */
 	public GameMapList getDataGameMapList(Region region, String locale, String version) throws RiotApiException {
 
-		return StaticDataApi.getDataGameMapList(region.getName(), getKey(), locale, version);
+		return StaticDataApi.getDataGameMapList(region, getKey(), locale, version);
 	}
 
 	/**
@@ -2000,7 +1998,7 @@ public class RiotApi {
 	 */
 	public GameMapList getDataGameMapList(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataGameMapList(region.getName(), getKey(), null, null);
+		return StaticDataApi.getDataGameMapList(region, getKey(), null, null);
 	}
 
 	/**
@@ -2036,7 +2034,7 @@ public class RiotApi {
 	 */
 	public ItemList getDataItemList(Region region, String locale, String version, ItemListData... itemListData) throws RiotApiException {
 
-		return StaticDataApi.getDataItemList(region.getName(), getKey(), locale, version, itemListData);
+		return StaticDataApi.getDataItemList(region, getKey(), locale, version, itemListData);
 	}
 
 	/**
@@ -2072,7 +2070,7 @@ public class RiotApi {
 	 */
 	public ItemList getDataItemList(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataItemList(region.getName(), getKey(), null, null, (ItemListData) null);
+		return StaticDataApi.getDataItemList(region, getKey(), null, null, (ItemListData) null);
 	}
 
 	/**
@@ -2110,7 +2108,7 @@ public class RiotApi {
 	 */
 	public Item getDataItem(Region region, int id, String locale, String version, ItemData... itemData) throws RiotApiException {
 
-		return StaticDataApi.getDataItem(region.getName(), getKey(), id, locale, version, itemData);
+		return StaticDataApi.getDataItem(region, getKey(), id, locale, version, itemData);
 	}
 
 	/**
@@ -2150,7 +2148,7 @@ public class RiotApi {
 	 */
 	public Item getDataItem(Region region, int id) throws RiotApiException {
 
-		return StaticDataApi.getDataItem(region.getName(), getKey(), id, null, null, (ItemData) null);
+		return StaticDataApi.getDataItem(region, getKey(), id, null, null, (ItemData) null);
 	}
 
 	/**
@@ -2179,7 +2177,7 @@ public class RiotApi {
 	 */
 	public List<String> getDataLanguages(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataLanguages(region.getName(), getKey());
+		return StaticDataApi.getDataLanguages(region, getKey());
 	}
 
 	/**
@@ -2211,7 +2209,7 @@ public class RiotApi {
 	 */
 	public LanguageStrings getDataLanguageStrings(Region region, String locale, String version) throws RiotApiException {
 
-		return StaticDataApi.getDataLanguageStrings(region.getName(), getKey(), locale, version);
+		return StaticDataApi.getDataLanguageStrings(region, getKey(), locale, version);
 	}
 
 	/**
@@ -2244,7 +2242,7 @@ public class RiotApi {
 	 */
 	public LanguageStrings getDataLanguageStrings(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataLanguageStrings(region.getName(), getKey(), null, null);
+		return StaticDataApi.getDataLanguageStrings(region, getKey(), null, null);
 	}
 
 	/**
@@ -2280,7 +2278,7 @@ public class RiotApi {
 	 */
 	public MasteryList getDataMasteryList(Region region, String locale, String version, MasteryListData... masteryListData) throws RiotApiException {
 
-		return StaticDataApi.getDataMasteryList(region.getName(), getKey(), locale, version, masteryListData);
+		return StaticDataApi.getDataMasteryList(region, getKey(), locale, version, masteryListData);
 	}
 
 	/**
@@ -2316,7 +2314,7 @@ public class RiotApi {
 	 */
 	public MasteryList getDataMasteryList(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataMasteryList(region.getName(), getKey(), null, null, (MasteryListData) null);
+		return StaticDataApi.getDataMasteryList(region, getKey(), null, null, (MasteryListData) null);
 	}
 
 	/**
@@ -2354,7 +2352,7 @@ public class RiotApi {
 	 */
 	public Mastery getDataMastery(Region region, int id, String locale, String version, MasteryData... masteryData) throws RiotApiException {
 
-		return StaticDataApi.getDataMastery(region.getName(), getKey(), id, locale, version, masteryData);
+		return StaticDataApi.getDataMastery(region, getKey(), id, locale, version, masteryData);
 	}
 
 	/**
@@ -2394,7 +2392,7 @@ public class RiotApi {
 	 */
 	public Mastery getDataMastery(Region region, int id) throws RiotApiException {
 
-		return StaticDataApi.getDataMastery(region.getName(), getKey(), id, null, null, (MasteryData) null);
+		return StaticDataApi.getDataMastery(region, getKey(), id, null, null, (MasteryData) null);
 	}
 
 	/**
@@ -2424,7 +2422,7 @@ public class RiotApi {
 	 */
 	public Realm getDataRealm(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataRealm(region.getName(), getKey());
+		return StaticDataApi.getDataRealm(region, getKey());
 	}
 
 	/**
@@ -2460,7 +2458,7 @@ public class RiotApi {
 	 */
 	public RuneList getDataRuneList(Region region, String locale, String version, RuneListData... runeListData) throws RiotApiException {
 
-		return StaticDataApi.getDataRuneList(region.getName(), getKey(), locale, version, runeListData);
+		return StaticDataApi.getDataRuneList(region, getKey(), locale, version, runeListData);
 	}
 
 	/**
@@ -2496,7 +2494,7 @@ public class RiotApi {
 	 */
 	public RuneList getDataRuneList(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataRuneList(region.getName(), getKey(), null, null, (RuneListData) null);
+		return StaticDataApi.getDataRuneList(region, getKey(), null, null, (RuneListData) null);
 	}
 
 	/**
@@ -2534,7 +2532,7 @@ public class RiotApi {
 	 */
 	public Rune getDataRune(Region region, int id, String locale, String version, RuneData... runeData) throws RiotApiException {
 
-		return StaticDataApi.getDataRune(region.getName(), getKey(), id, locale, version, runeData);
+		return StaticDataApi.getDataRune(region, getKey(), id, locale, version, runeData);
 	}
 
 	/**
@@ -2574,7 +2572,7 @@ public class RiotApi {
 	 */
 	public Rune getDataRune(Region region, int id) throws RiotApiException {
 
-		return StaticDataApi.getDataRune(region.getName(), getKey(), id, null, null, (RuneData) null);
+		return StaticDataApi.getDataRune(region, getKey(), id, null, null, (RuneData) null);
 	}
 
 	/**
@@ -2616,7 +2614,7 @@ public class RiotApi {
 	public SummonerSpellList getDataSummonerSpellList(Region region, String locale, String version, boolean dataById, SpellData... spellData)
 			throws RiotApiException {
 
-		return StaticDataApi.getDataSummonerSpellList(region.getName(), getKey(), locale, version, dataById, spellData);
+		return StaticDataApi.getDataSummonerSpellList(region, getKey(), locale, version, dataById, spellData);
 	}
 
 	/**
@@ -2655,7 +2653,7 @@ public class RiotApi {
 	 */
 	public SummonerSpellList getDataSummonerSpellList(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataSummonerSpellList(region.getName(), getKey(), null, null, false, (SpellData) null);
+		return StaticDataApi.getDataSummonerSpellList(region, getKey(), null, null, false, (SpellData) null);
 	}
 
 	/**
@@ -2693,7 +2691,7 @@ public class RiotApi {
 	 */
 	public SummonerSpell getDataSummonerSpell(Region region, int id, String locale, String version, SpellData... spellData) throws RiotApiException {
 
-		return StaticDataApi.getDataSummonerSpell(region.getName(), getKey(), id, locale, version, spellData);
+		return StaticDataApi.getDataSummonerSpell(region, getKey(), id, locale, version, spellData);
 	}
 
 	/**
@@ -2733,7 +2731,7 @@ public class RiotApi {
 	 */
 	public SummonerSpell getDataSummonerSpell(Region region, int id) throws RiotApiException {
 
-		return StaticDataApi.getDataSummonerSpell(region.getName(), getKey(), id, null, null, (SpellData) null);
+		return StaticDataApi.getDataSummonerSpell(region, getKey(), id, null, null, (SpellData) null);
 	}
 
 	/**
@@ -2762,7 +2760,7 @@ public class RiotApi {
 	 */
 	public List<String> getDataVersions(Region region) throws RiotApiException {
 
-		return StaticDataApi.getDataVersions(region.getName(), getKey());
+		return StaticDataApi.getDataVersions(region, getKey());
 	}
 
 	/**
@@ -2802,7 +2800,7 @@ public class RiotApi {
 	 */
 	public ShardStatus getShardStatus(Region region) throws RiotApiException {
 
-		return StatusApi.getShardStatus(region.getName());
+		return StatusApi.getShardStatus(region);
 	}
 
 	/**
@@ -2823,11 +2821,8 @@ public class RiotApi {
 	 *
 	 * @return The currently set season
 	 */
-	public String getSeason() {
-		if (season == null) {
-			return null;
-		}
-		return season.getName();
+	public Season getSeason() {
+		return season;
 	}
 
 	/**
@@ -2845,8 +2840,8 @@ public class RiotApi {
 	 * @return The currently set region
 	 * @throws
 	 */
-	public String getRegion() {
-		return region.getName();
+	public Region getRegion() {
+		return region;
 	}
 
 	/**
@@ -2877,20 +2872,15 @@ public class RiotApi {
 	 */
 	public void setRegion(Region region) {
 		this.region = region;
-		setEndpoint();
 	}
 
 	/**
-	 * Get the base URL for all API requests
+	 * Get the base URL for API requests
 	 *
-	 * @return The base URL for all API requests
+	 * @return The base URL for API requests
 	 */
 	public String getEndpoint() {
-		return endpoint;
-	}
-
-	private void setEndpoint() {
-		this.endpoint = region.getEndpoint();
+		return region.getEndpoint();
 	}
 
 	@Override

--- a/src/main/java/riotapi/RiotApi.java
+++ b/src/main/java/riotapi/RiotApi.java
@@ -242,6 +242,38 @@ public class RiotApi {
 	}
 
 	/**
+	 * Get leagues for a given summoner ID.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve recent games.
+	 * @return Recent games of the given summoner
+	 * @see RecentGames
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public RecentGames getRecentGames(Region region, String summonerId) throws RiotApiException {
+
+		return GameApi.getRecentGames(region.getEndpoint(), region.getName(), getKey(), summonerId);
+	}
+
+	/**
+	 * Get leagues for a given summoner ID.
+	 *
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve recent games.
+	 * @return Recent games of the given summoner
+	 * @see RecentGames
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public RecentGames getRecentGames(String summonerId) throws RiotApiException {
+
+		return GameApi.getRecentGames(getEndpoint(), getRegion(), getKey(), summonerId);
+	}
+
+	/**
 	 * Get a list of leagues for a summoner
 	 * 
 	 * @param region

--- a/src/main/java/riotapi/RiotApi.java
+++ b/src/main/java/riotapi/RiotApi.java
@@ -1263,210 +1263,251 @@ public class RiotApi {
         return name;
     }
 
-    /**
-     * Get teams by summonerIDs
-     *
-     * @param region The desired region
-     * @param summonerIds A list of summoner IDs
-     * @return A map of the summoners' teams
-     * @see Team
-     * @throws RiotApiException
-     */
-    public Map<String, List<Team>> getTeamsBySummonerIds(Region region, long... summonerIds) throws RiotApiException {
+	/**
+	 * Get teams for multiple summoners by summoner ID
+	 *
+	 * @param region
+	 *            The region of the summoner.
+	 * @param summonerIds
+	 *            A list of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map of the summoners' teams
+	 * @see Team
+	 * @throws RiotApiException
+	 */
+	public Map<String, List<Team>> getTeamsBySummonerIds(Region region, long... summonerIds) throws RiotApiException {
 
-        return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
-    
-    /**
-     * Get teams by summonerID
-     *
-     * @param region The desired region
-     * @param summonerId A summoner ID
-     * @return A list of the summoners' teams
-     * @see Team
-     * @throws RiotApiException
-     */
-    public List<Team> getTeamsBySummonerId(Region region, long summonerId) throws RiotApiException {
+		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
 
-        return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
-    }
+	/**
+	 * Get teams for a summoner by summoner ID
+	 *
+	 * @param region
+	 *            The region of the summoner.
+	 * @param summonerId
+	 *            Summoner ID
+	 * @return A list of the summoner's teams
+	 * @see Team
+	 * @throws RiotApiException
+	 */
+	public List<Team> getTeamsBySummonerId(Region region, long summonerId) throws RiotApiException {
 
-    /**
-     * Get teams by summonerIDs
-     *
-     * @param summonerIds A list of summoner IDs
-     * @return A map of the summoners' teams
-     * @see Team
-     * @throws RiotApiException
-     */
-    public Map<String, List<Team>> getTeamsBySummonerIds(long... summonerIds) throws RiotApiException {
+		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
 
-        return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
-    
-    /**
-     * Get teams by summonerID
-     *
-     * @param summonerId A summoner ID
-     * @return A list of the summoners' teams
-     * @see Team
-     * @throws RiotApiException
-     */
-    public List<Team> getTeamsBySummonerId(long summonerId) throws RiotApiException {
+	/**
+	 * Get teams for multiple summoners by summoner ID
+	 *
+	 * @param summonerIds
+	 *            A list of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map of the summoners' teams
+	 * @see Team
+	 * @throws RiotApiException
+	 */
+	public Map<String, List<Team>> getTeamsBySummonerIds(long... summonerIds) throws RiotApiException {
 
-        return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
-    }
+		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
 
-    /**
-     * Get teams by summonerIDs
-     *
-     * @param region The desired region
-     * @param summonerIds Comma-separated list of summoner IDs
-     * @return A map of the summoners' teams
-     * @see Team
-     * @throws RiotApiException
-     */
-    public Map<String, List<Team>> getTeamsBySummonerIds(Region region, String summonerIds) throws RiotApiException {
+	/**
+	 * Get teams for a summoner by summoner ID
+	 *
+	 * @param summonerId
+	 *            A summoner ID
+	 * @return A list of the summoner's teams
+	 * @see Team
+	 * @throws RiotApiException
+	 */
+	public List<Team> getTeamsBySummonerId(long summonerId) throws RiotApiException {
 
-        return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
+		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
 
-    /**
-     * Get teams by summonerIDs
-     *
-     * @param summonerIds Comma-separated list of summoner IDs
-     * @return A map of the summoners' teams
-     * @see Team
-     * @throws RiotApiException
-     */
-    public Map<String, List<Team>> getTeamsBySummonerIds(String summonerIds) throws RiotApiException {
+	/**
+	 * Get teams for multiple summoners by summoner ID
+	 *
+	 * @param region
+	 *            The region of the summoner.
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map of the summoners' teams
+	 * @see Team
+	 * @throws RiotApiException
+	 */
+	public Map<String, List<Team>> getTeamsBySummonerIds(Region region, String summonerIds) throws RiotApiException {
 
-        return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
+		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
 
-    /**
-     * Get match by ID
-     *
-     * @param region The desired region
-     * @param matchId The ID of the match
-     * @return A map with match details
-     * @see MatchDetail
-     * @throws RiotApiException
-     */
-    public MatchDetail getMatch(Region region, long matchId) throws RiotApiException {
+	/**
+	 * Get teams for multiple summoners by summoner ID
+	 *
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs
+	 * @return A map of the summoners' teams
+	 * @see Team
+	 * @throws RiotApiException
+	 */
+	public Map<String, List<Team>> getTeamsBySummonerIds(String summonerIds) throws RiotApiException {
 
-        return MatchApi.getMatch(region.getEndpoint(), region.getName(), getKey(), matchId);
-    }
+		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
 
-    /**
-     * Get match by ID
-     *
-     * @param matchId The ID of the match
-     * @return A map with match details
-     * @see MatchDetail
-     * @throws RiotApiException
-     */
-    public MatchDetail getMatch(long matchId) throws RiotApiException {
+	/**
+	 * Get match by ID
+	 *
+	 * @param region
+	 *            The region of the summoner.
+	 * @param matchId
+	 *            The ID of the match.
+	 * @return A map with match details
+	 * @see MatchDetail
+	 * @throws RiotApiException
+	 */
+	public MatchDetail getMatch(Region region, long matchId) throws RiotApiException {
 
-        return MatchApi.getMatch(getEndpoint(), getRegion(), getKey(), matchId);
-    }
+		return MatchApi.getMatch(region.getEndpoint(), region.getName(), getKey(), matchId);
+	}
 
-    /**
-     * Get match by ID
-     *
-     * @param region The desired region
-     * @param matchId The ID of the match
-     * @param includeTimeline Flag indicating whether or not to include match timeline data
-     * @return A map with match details
-     * @see MatchDetail
-     * @throws RiotApiException
-     */
-    public MatchDetail getMatch(Region region, long matchId, boolean includeTimeline) throws RiotApiException {
+	/**
+	 * Get match by ID
+	 *
+	 * @param matchId
+	 *            The ID of the match
+	 * @return A map with match details
+	 * @see MatchDetail
+	 * @throws RiotApiException
+	 */
+	public MatchDetail getMatch(long matchId) throws RiotApiException {
 
-        return MatchApi.getMatch(region.getEndpoint(), region.getName(), getKey(), matchId, includeTimeline);
-    }
+		return MatchApi.getMatch(getEndpoint(), getRegion(), getKey(), matchId);
+	}
 
-    /**
-     * Get match by ID
-     *
-     * @param matchId The ID of the match
-     * @param includeTimeline Flag indicating whether or not to include match timeline data
-     * @return A map with match details
-     * @see MatchDetail
-     * @throws RiotApiException
-     */
-    public MatchDetail getMatch(long matchId, boolean includeTimeline) throws RiotApiException {
+	/**
+	 * Get match by ID
+	 *
+	 * @param region
+	 *            The region of the summoner.
+	 * @param matchId
+	 *            The ID of the match.
+	 * @param includeTimeline
+	 *            Flag indicating whether or not to include match timeline data
+	 * @return A map with match details
+	 * @see MatchDetail
+	 * @throws RiotApiException
+	 */
+	public MatchDetail getMatch(Region region, long matchId, boolean includeTimeline) throws RiotApiException {
 
-        return MatchApi.getMatch(getEndpoint(), getRegion(), getKey(), matchId, includeTimeline);
-    }
+		return MatchApi.getMatch(region.getEndpoint(), region.getName(), getKey(), matchId, includeTimeline);
+	}
 
-    /**
-     * Get match list by summonerID
-     *
-     * @param region The desired region
-     * @param summonerId The ID of the desired summoner
-     * @param championIds Comma-separated list of champion IDs to use for fetching games.
-     * @param rankedQueues Comma-separated list of ranked queue types to use for fetching games
-     * @param seasons Comma-separated list of seasons to use for fetching games.
-     * @param beginTime The begin time to use for fetching games specified as epoch milliseconds.
-     * @param endTime The end time to use for fetching games specified as epoch milliseconds.
-     * @param beginIndex The begin index to use for fetching games
-     * @param endIndex The end index to use for fetching games
-     * @return A list with matches
-     * @see MatchList
-     * @throws RiotApiException
-     */
-    public MatchList getMatchList(Region region, long summonerId, String championIds, String rankedQueues, String seasons, long beginTime, long endTime, int beginIndex, int endIndex) throws RiotApiException {
+	/**
+	 * Get match by ID
+	 *
+	 * @param matchId
+	 *            The ID of the match.
+	 * @param includeTimeline
+	 *            Flag indicating whether or not to include match timeline data
+	 * @return A map with match details
+	 * @see MatchDetail
+	 * @throws RiotApiException
+	 */
+	public MatchDetail getMatch(long matchId, boolean includeTimeline) throws RiotApiException {
 
-        return MatchListApi.getMatchList(region.getEndpoint(), region.getName(), getKey(), summonerId, championIds, rankedQueues, seasons, beginTime, endTime, beginIndex, endIndex);
-    }
-    
-    /**
-     * Get match list by summonerID
-     *
-     * @param region The desired region
-     * @param summonerId The ID of the desired summoner
-     * @return A list with matches
-     * @see MatchList
-     * @throws RiotApiException
-     */
-    public MatchList getMatchList(Region region, long summonerId) throws RiotApiException {
+		return MatchApi.getMatch(getEndpoint(), getRegion(), getKey(), matchId, includeTimeline);
+	}
 
-        return MatchListApi.getMatchList(region.getEndpoint(), region.getName(), getKey(), summonerId, null, null, null, -1, -1, -1, -1);
-    }
-    
-    /**
-     * Get match list by summonerID
-     *
-     * @param summonerId The ID of the desired summoner
-     * @param championIds Comma-separated list of champion IDs to use for fetching games.
-     * @param rankedQueues Comma-separated list of ranked queue types to use for fetching games
-     * @param seasons Comma-separated list of seasons to use for fetching games.
-     * @param beginTime The begin time to use for fetching games specified as epoch milliseconds.
-     * @param endTime The end time to use for fetching games specified as epoch milliseconds.
-     * @param beginIndex The begin index to use for fetching games
-     * @param endIndex The end index to use for fetching games
-     * @return A list with matches
-     * @see MatchList
-     * @throws RiotApiException
-     */
-    public MatchList getMatchList(long summonerId, String championIds, String rankedQueues, String seasons, long beginTime, long endTime, int beginIndex, int endIndex) throws RiotApiException {
+	/**
+	 * Get match list by summonerID
+	 *
+	 * @param region
+	 *            The region of the summoner.
+	 * @param summonerId
+	 *            The ID of the summoner.
+	 * @param championIds
+	 *            Comma-separated list of champion IDs to use for fetching games.
+	 * @param rankedQueues
+	 *            Comma-separated list of ranked queue types to use for fetching games. Non-ranked queue types will be ignored.
+	 * @param seasons
+	 *            Comma-separated list of seasons to use for fetching games.
+	 * @param beginTime
+	 *            The begin time to use for fetching games specified as epoch milliseconds.
+	 * @param endTime
+	 *            The end time to use for fetching games specified as epoch milliseconds.
+	 * @param beginIndex
+	 *            The begin index to use for fetching games.
+	 * @param endIndex
+	 *            The end index to use for fetching games.
+	 * @return A list with matches
+	 * @see MatchList
+	 * @throws RiotApiException
+	 */
+	public MatchList getMatchList(Region region, long summonerId, String championIds, String rankedQueues, String seasons, long beginTime, long endTime,
+			int beginIndex, int endIndex) throws RiotApiException {
 
-        return MatchListApi.getMatchList(getEndpoint(), getRegion(), getKey(), summonerId, championIds, rankedQueues, seasons, beginTime, endTime, beginIndex, endIndex);
-    }
-    
-    /**
-     * Get match list by summonerID
-     *
-     * @param summonerId The ID of the desired summoner
-     * @return A list with matches
-     * @see MatchList
-     * @throws RiotApiException
-     */
-    public MatchList getMatchList(long summonerId) throws RiotApiException {
+		return MatchListApi.getMatchList(region.getEndpoint(), region.getName(), getKey(), summonerId, championIds, rankedQueues, seasons, beginTime, endTime,
+				beginIndex, endIndex);
+	}
 
-        return MatchListApi.getMatchList(getEndpoint(), getRegion(), getKey(), summonerId, null, null, null, -1, -1, -1, -1);
-    }
+	/**
+	 * Get match list by summonerID
+	 *
+	 * @param The
+	 *            region of the summoner.
+	 * @param summonerId
+	 *            The ID of the summoner.
+	 * @return A list with matches
+	 * @see MatchList
+	 * @throws RiotApiException
+	 */
+	public MatchList getMatchList(Region region, long summonerId) throws RiotApiException {
+
+		return MatchListApi.getMatchList(region.getEndpoint(), region.getName(), getKey(), summonerId, null, null, null, -1, -1, -1, -1);
+	}
+
+	/**
+	 * Get match list by summonerID
+	 *
+	 * @param summonerId
+	 *            The ID of the summoner.
+	 * @param championIds
+	 *            Comma-separated list of champion IDs to use for fetching games.
+	 * @param rankedQueues
+	 *            Comma-separated list of ranked queue types to use for fetching games. Non-ranked queue types will be ignored.
+	 * @param seasons
+	 *            Comma-separated list of seasons to use for fetching games.
+	 * @param beginTime
+	 *            The begin time to use for fetching games specified as epoch milliseconds.
+	 * @param endTime
+	 *            The end time to use for fetching games specified as epoch milliseconds.
+	 * @param beginIndex
+	 *            The begin index to use for fetching games.
+	 * @param endIndex
+	 *            The end index to use for fetching games.
+	 * @return A list with matches
+	 * @see MatchList
+	 * @throws RiotApiException
+	 */
+	public MatchList getMatchList(long summonerId, String championIds, String rankedQueues, String seasons, long beginTime, long endTime, int beginIndex,
+			int endIndex) throws RiotApiException {
+
+		return MatchListApi.getMatchList(getEndpoint(), getRegion(), getKey(), summonerId, championIds, rankedQueues, seasons, beginTime, endTime, beginIndex,
+				endIndex);
+	}
+
+	/**
+	 * Get match list by summonerID
+	 *
+	 * @param summonerId
+	 *            The ID of the summoner.
+	 * @return A list with matches
+	 * @see MatchList
+	 * @throws RiotApiException
+	 */
+	public MatchList getMatchList(long summonerId) throws RiotApiException {
+
+		return MatchListApi.getMatchList(getEndpoint(), getRegion(), getKey(), summonerId, null, null, null, -1, -1, -1, -1);
+	}
     
 	/**
 	 * Get current game info

--- a/src/main/java/riotapi/RiotApi.java
+++ b/src/main/java/riotapi/RiotApi.java
@@ -1,12 +1,5 @@
 package main.java.riotapi;
 
-/**
- * Riot Games API Java Library
- * riot-api-java
- * by Taylor Caldwell - @rithms
- * http://rithms.im 
- */
-
 /*
  * Copyright 2014 Taylor Caldwell
  *
@@ -65,15 +58,18 @@ import dto.Summoner.MasteryPages;
 import dto.Summoner.RunePages;
 import dto.Summoner.Summoner;
 
+/**
+ * Riot Games API Java Library - riot-api-java
+ * 
+ * @author Taylor Caldwell - rithms - http://rithms.im
+ */
 public class RiotApi {
 
-    /**
-     * The base URL for all API requests
-     */
+    // The base URL for all API requests
     private String endpoint = Region.GLOBAL.getEndpoint();
 
     private Region region = Region.NA; // North American region default
-    private Season season = null;
+    private Season season = Season.CURRENT; // Current season default
     private String key;
 
     public RiotApi() {

--- a/src/main/java/riotapi/RiotApi.java
+++ b/src/main/java/riotapi/RiotApi.java
@@ -61,39 +61,41 @@ import dto.Summoner.Summoner;
 /**
  * Riot Games API Java Library - riot-api-java
  * 
- * @author Taylor Caldwell - rithms - http://rithms.im
+ * @author Taylor 'rithms' Caldwell - http://rithms.im
+ * @version 3.6.2
  */
 public class RiotApi {
 
-    // The base URL for all API requests
-    private String endpoint = Region.GLOBAL.getEndpoint();
+	// The base URL for all API requests
+	private String endpoint = Region.GLOBAL.getEndpoint();
 
-    private Region region = Region.NA; // North American region default
-    private Season season = Season.CURRENT; // Current season default
-    private String key;
+	private Region region = Region.NA; // North American region default
+	private Season season = Season.CURRENT; // Current season default
+	private String key;
 
-    public RiotApi() {
-    }
+	public RiotApi() {
+	}
 
-    public RiotApi(String key) {
-        this.setKey(key);
-    }
+	public RiotApi(String key) {
+		this.setKey(key);
+	}
 
-    public RiotApi(Region region) {
-        this.setRegion(region);
-    }
+	public RiotApi(Region region) {
+		this.setRegion(region);
+	}
 
-    public RiotApi(String key, Region region) {
-        this.setKey(key);
-        this.setRegion(region);
-    }
+	public RiotApi(String key, Region region) {
+		this.setKey(key);
+		this.setRegion(region);
+	}
 
 	/**
-	 * Get all the champions for a set region
+	 * Retrieve all champions.
 	 *
 	 * @return A list of all the champions for the set region
 	 * @see dto.Champion.ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Champion.ChampionList getChampions() throws RiotApiException {
 
@@ -101,13 +103,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get all the champions for a given region
+	 * Retrieve all champions.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
 	 * @return A list of champions for the given region
 	 * @see dto.Champion.ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Champion.ChampionList getChampions(Region region) throws RiotApiException {
 
@@ -115,13 +118,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get all the champions for a set region
+	 * Retrieve all champions.
 	 *
 	 * @param freeToPlay
 	 *            Optional filter param to retrieve only free to play champions.
 	 * @return A list of champions for the set region
 	 * @see dto.Champion.ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Champion.ChampionList getChampions(boolean freeToPlay) throws RiotApiException {
 
@@ -129,7 +133,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get all champions for a given region
+	 * Retrieve all champions.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -138,6 +142,7 @@ public class RiotApi {
 	 * @return A list of champions for the given region
 	 * @see dto.Champion.ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Champion.ChampionList getChampions(Region region, boolean freeToPlay) throws RiotApiException {
 
@@ -145,13 +150,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get all free to play champions for a given region
+	 * Retrieve all champions that are free-to-play.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
 	 * @return A list of all the free to play champions for the given region
 	 * @see dto.Champion.ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Champion.ChampionList getFreeToPlayChampions(Region region) throws RiotApiException {
 
@@ -159,11 +165,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get all free to play champions for a set region
+	 * Retrieve all champions that are free-to-play.
 	 *
 	 * @return A list of all the free to play champions for the set region
 	 * @see dto.Champion.ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Champion.ChampionList getFreeToPlayChampions() throws RiotApiException {
 
@@ -171,7 +178,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a champion by id for a given region
+	 * Retrieve champion by ID.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -180,6 +187,7 @@ public class RiotApi {
 	 * @return The champion of the given ID
 	 * @see Champion
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Champion getChampionById(Region region, int champId) throws RiotApiException {
 
@@ -187,13 +195,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a champion by id for a set region
+	 * Retrieve champion by ID.
 	 *
 	 * @param champId
 	 *            The ID of the desired champion
 	 * @return The champion of the given ID
 	 * @see Champion
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Champion getChampionById(int champId) throws RiotApiException {
 
@@ -201,7 +210,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get recent games for a given summoner
+	 * Get leagues for a given summoner ID.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -210,6 +219,7 @@ public class RiotApi {
 	 * @return Recent games of the given summoner
 	 * @see RecentGames
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RecentGames getRecentGames(Region region, long summonerId) throws RiotApiException {
 
@@ -217,13 +227,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get recent games for a given summoner
+	 * Get leagues for a given summoner ID.
 	 *
 	 * @param summonerId
 	 *            ID of the summoner for which to retrieve recent games.
 	 * @return Recent games of the given summoner
 	 * @see RecentGames
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RecentGames getRecentGames(long summonerId) throws RiotApiException {
 
@@ -240,6 +251,7 @@ public class RiotApi {
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueBySummoner(Region region, long summonerId) throws RiotApiException {
 
@@ -247,29 +259,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of leagues for multiple summoners
-	 * 
-	 * @param region
-	 *            The region of the leagues.
-	 * @param summonerIds
-	 *            List of summoner IDs. Maximum allowed at once is 10.
-	 * @return A map, mapping each summoner ID to a list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<League>> getLeagueBySummoners(Region region, long... summonerIds) throws RiotApiException {
-
-		return LeagueApi.getLeagueBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get a list of leagues for a summoner
+	 * Get leagues for a given summoner ID.
 	 * 
 	 * @param summonerId
 	 *            Summoner ID
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueBySummoner(long summonerId) throws RiotApiException {
 
@@ -277,20 +274,6 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of leagues for multiple summoners
-	 * 
-	 * @param summonerIds
-	 *            List of summoner IDs. Maximum allowed at once is 10.
-	 * @return A map, mapping each summoner ID to a list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<League>> getLeagueBySummoners(long... summonerIds) throws RiotApiException {
-
-		return LeagueApi.getLeagueBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
-	}
-
-	/**
 	 * Get a list of leagues for a summoner
 	 * 
 	 * @param region
@@ -300,66 +283,7 @@ public class RiotApi {
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
-	 */
-	public List<League> getLeagueEntryBySummoner(Region region, long summonerId) throws RiotApiException {
-
-		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
-	}
-
-	/**
-	 * Get a list of leagues for multiple summoners
-	 * 
-	 * @param region
-	 *            The region of the leagues.
-	 * @param summonerIds
-	 *            List of summoner IDs. Maximum allowed at once is 10.
-	 * @return A map, mapping each summoner ID to a list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<League>> getLeagueEntryBySummoners(Region region, long... summonerIds) throws RiotApiException {
-
-		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get a list of leagues for a summoner
-	 * 
-	 * @param summonerId
-	 *            Summoner ID
-	 * @return A list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public List<League> getLeagueEntryBySummoner(long summonerId) throws RiotApiException {
-
-		return LeagueApi.getLeagueEntryBySummoners(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
-	}
-
-	/**
-	 * Get a list of leagues for multiple summoners
-	 * 
-	 * @param summonerIds
-	 *            List of summoner IDs. Maximum allowed at once is 10.
-	 * @return A map, mapping each summoner ID to a list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<League>> getLeagueEntryBySummoners(long... summonerIds) throws RiotApiException {
-
-		return LeagueApi.getLeagueEntryBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get a list of leagues for a summoner
-	 * 
-	 * @param region
-	 *            The region of the leagues.
-	 * @param summonerId
-	 *            Summoner ID
-	 * @return A list of leagues
-	 * @see League
-	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueBySummoner(Region region, String summonerId) throws RiotApiException {
 
@@ -367,22 +291,6 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of leagues for multiple summoners
-	 * 
-	 * @param region
-	 *            The region of the leagues.
-	 * @param summonerIds
-	 *            List of summoner IDs. Maximum allowed at once is 10.
-	 * @return A map, mapping each summoner ID to a list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<League>> getLeagueBySummoners(Region region, String summonerIds) throws RiotApiException {
-
-		return LeagueApi.getLeagueBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-	}
-
-	/**
 	 * Get a list of leagues for a summoner
 	 * 
 	 * @param summonerId
@@ -390,26 +298,77 @@ public class RiotApi {
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueBySummoner(String summonerId) throws RiotApiException {
 		return LeagueApi.getLeagueBySummoners(getEndpoint(), getRegion(), getKey(), summonerId).get(summonerId);
 	}
 
 	/**
-	 * Get a list of leagues for multiple summoners
+	 * Get leagues mapped by summoner ID for a given list of summoner IDs.
+	 * 
+	 * @param region
+	 *            The region of the leagues.
+	 * @param summonerIds
+	 *            List of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map, mapping each summoner ID to a list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<League>> getLeagueBySummoners(Region region, long... summonerIds) throws RiotApiException {
+
+		return LeagueApi.getLeagueBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get leagues mapped by summoner ID for a given list of summoner IDs.
 	 * 
 	 * @param summonerIds
 	 *            List of summoner IDs. Maximum allowed at once is 10.
 	 * @return A map, mapping each summoner ID to a list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<League>> getLeagueBySummoners(long... summonerIds) throws RiotApiException {
+
+		return LeagueApi.getLeagueBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get a list of leagues for multiple summoners
+	 * 
+	 * @param region
+	 *            The region of the leagues.
+	 * @param summonerIds
+	 *            List of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map, mapping each summoner ID to a list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<League>> getLeagueBySummoners(Region region, String summonerIds) throws RiotApiException {
+
+		return LeagueApi.getLeagueBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get league entries mapped by summoner ID for a given list of summoner IDs.
+	 * 
+	 * @param summonerIds
+	 *            List of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map, mapping each summoner ID to a list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Map<String, List<League>> getLeagueBySummoners(String summonerIds) throws RiotApiException {
 		return LeagueApi.getLeagueBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
 	}
 
 	/**
-	 * Get a list of league entries for a summoner
+	 * Get league entries for a given summoner ID.
 	 * 
 	 * @param region
 	 *            The region of the leagues.
@@ -418,6 +377,39 @@ public class RiotApi {
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public List<League> getLeagueEntryBySummoner(Region region, long summonerId) throws RiotApiException {
+
+		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
+
+	/**
+	 * Get league entries for a given summoner ID.
+	 * 
+	 * @param summonerId
+	 *            Summoner ID
+	 * @return A list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public List<League> getLeagueEntryBySummoner(long summonerId) throws RiotApiException {
+
+		return LeagueApi.getLeagueEntryBySummoners(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
+
+	/**
+	 * Get league entries for a given summoner ID.
+	 * 
+	 * @param region
+	 *            The region of the leagues.
+	 * @param summonerId
+	 *            Summoner ID
+	 * @return A list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueEntryBySummoner(Region region, String summonerId) throws RiotApiException {
 
@@ -425,29 +417,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of league entries for multiple summoners
-	 * 
-	 * @param region
-	 *            The region of the leagues.
-	 * @param summonerIds
-	 *            List of summoner IDs. Maximum allowed at once is 10.
-	 * @return A map, mapping each summoner ID to a list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<League>> getLeagueEntryBySummoners(Region region, String summonerIds) throws RiotApiException {
-
-		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get a list of league entries for a summoner
+	 * Get league entries for a given summoner ID.
 	 * 
 	 * @param summonerId
 	 *            Summoner ID
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueEntryBySummoner(String summonerId) throws RiotApiException {
 
@@ -455,13 +432,63 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of league entries for multiple summoners
+	 * Get league entries mapped by summoner ID for a given list of summoner IDs.
+	 * 
+	 * @param region
+	 *            The region of the leagues.
+	 * @param summonerIds
+	 *            List of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map, mapping each summoner ID to a list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<League>> getLeagueEntryBySummoners(Region region, long... summonerIds) throws RiotApiException {
+
+		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get league entries mapped by summoner ID for a given list of summoner IDs.
 	 * 
 	 * @param summonerIds
 	 *            List of summoner IDs. Maximum allowed at once is 10.
 	 * @return A map, mapping each summoner ID to a list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<League>> getLeagueEntryBySummoners(long... summonerIds) throws RiotApiException {
+
+		return LeagueApi.getLeagueEntryBySummoners(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get league entries mapped by summoner ID for a given list of summoner IDs.
+	 * 
+	 * @param region
+	 *            The region of the leagues.
+	 * @param summonerIds
+	 *            List of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map, mapping each summoner ID to a list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<League>> getLeagueEntryBySummoners(Region region, String summonerIds) throws RiotApiException {
+
+		return LeagueApi.getLeagueEntryBySummoners(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get league entries mapped by summoner ID for a given list of summoner IDs.
+	 * 
+	 * @param summonerIds
+	 *            List of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map, mapping each summoner ID to a list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Map<String, List<League>> getLeagueEntryBySummoners(String summonerIds) throws RiotApiException {
 
@@ -469,7 +496,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of leagues for a team
+	 * Get leagues for a given team ID.
 	 * 
 	 * @param region
 	 *            The region of the leagues.
@@ -478,6 +505,7 @@ public class RiotApi {
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueByTeam(Region region, String teamId) throws RiotApiException {
 
@@ -485,29 +513,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of leagues for multiple teams
-	 * 
-	 * @param region
-	 *            The region of the leagues.
-	 * @param teamIds
-	 *            List of team IDs. Maximum allowed at once is 10.
-	 * @return A map, mapping each team ID to a list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<League>> getLeagueByTeams(Region region, String teamIds) throws RiotApiException {
-
-		return LeagueApi.getLeagueByTeams(region.getEndpoint(), region.getName(), getKey(), teamIds);
-	}
-
-	/**
-	 * Get a list of leagues for a team
+	 * Get leagues for a given team ID.
 	 * 
 	 * @param teamId
 	 *            Team ID
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueByTeam(String teamId) throws RiotApiException {
 
@@ -515,13 +528,31 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of leagues for multiple teams
+	 * Get leagues mapped by team ID for a given list of team IDs.
+	 * 
+	 * @param region
+	 *            The region of the leagues.
+	 * @param teamIds
+	 *            List of team IDs. Maximum allowed at once is 10.
+	 * @return A map, mapping each team ID to a list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<League>> getLeagueByTeams(Region region, String teamIds) throws RiotApiException {
+
+		return LeagueApi.getLeagueByTeams(region.getEndpoint(), region.getName(), getKey(), teamIds);
+	}
+
+	/**
+	 * Get leagues mapped by team ID for a given list of team IDs.
 	 * 
 	 * @param teamIds
 	 *            List of team IDs. Maximum allowed at once is 10.
 	 * @return A map, mapping each team ID to a list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Map<String, List<League>> getLeagueByTeams(String teamIds) throws RiotApiException {
 
@@ -529,7 +560,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of league entries for a team
+	 * Get league entries for a given team ID.
 	 * 
 	 * @param region
 	 *            The region of the leagues.
@@ -538,6 +569,7 @@ public class RiotApi {
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueEntryByTeam(Region region, String teamId) throws RiotApiException {
 
@@ -545,29 +577,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of league entries for multiple teams
-	 * 
-	 * @param region
-	 *            The region of the leagues.
-	 * @param teamIds
-	 *            List of team IDs. Maximum allowed at once is 10.
-	 * @return A map, mapping each team ID to a list of leagues
-	 * @see League
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<League>> getLeagueEntryByTeams(Region region, String teamIds) throws RiotApiException {
-
-		return LeagueApi.getLeagueEntryByTeams(region.getEndpoint(), region.getName(), getKey(), teamIds);
-	}
-
-	/**
-	 * Get a list of league entries for a team
+	 * Get league entries for a given team ID.
 	 * 
 	 * @param teamIds
 	 *            List of team IDs. Maximum allowed at once is 10.
 	 * @return A list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<League> getLeagueEntryByTeam(String teamId) throws RiotApiException {
 
@@ -575,13 +592,31 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a list of league entries for multiple teams
+	 * Get league entries mapped by team ID for a given list of team IDs.
+	 * 
+	 * @param region
+	 *            The region of the leagues.
+	 * @param teamIds
+	 *            List of team IDs. Maximum allowed at once is 10.
+	 * @return A map, mapping each team ID to a list of leagues
+	 * @see League
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<League>> getLeagueEntryByTeams(Region region, String teamIds) throws RiotApiException {
+
+		return LeagueApi.getLeagueEntryByTeams(region.getEndpoint(), region.getName(), getKey(), teamIds);
+	}
+
+	/**
+	 * Get league entries mapped by team ID for a given list of team IDs.
 	 * 
 	 * @param teamIds
 	 *            List of team IDs. Maximum allowed at once is 10.
 	 * @return A map, mapping each team ID to a list of leagues
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Map<String, List<League>> getLeagueEntryByTeams(String teamIds) throws RiotApiException {
 
@@ -589,13 +624,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get challenger league
+	 * Get challenger tier leagues.
 	 * 
 	 * @param region
 	 *            The region of the leagues.
 	 * @return A single league
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public League getChallengerLeague(Region region) throws RiotApiException {
 
@@ -603,11 +639,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get challenger league
+	 * Get challenger tier leagues.
 	 * 
 	 * @return A single league
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public League getChallengerLeague() throws RiotApiException {
 
@@ -615,7 +652,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get challenger league
+	 * Get challenger tier leagues.
 	 * 
 	 * @param region
 	 *            The region of the leagues.
@@ -624,6 +661,7 @@ public class RiotApi {
 	 * @return A single league
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public League getChallengerLeague(Region region, QueueType queueType) throws RiotApiException {
 
@@ -631,13 +669,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get challenger league
+	 * Get challenger tier leagues.
 	 * 
 	 * @param queueType
 	 *            Game queue type.
 	 * @return A single league
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public League getChallengerLeague(QueueType queueType) throws RiotApiException {
 
@@ -645,13 +684,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get master league
+	 * Get master tier leagues.
 	 * 
 	 * @param region
 	 *            The region of the leagues.
 	 * @return A single league
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public League getMasterLeague(Region region) throws RiotApiException {
 
@@ -659,11 +699,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get master league
+	 * Get master tier leagues.
 	 * 
 	 * @return A single league
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public League getMasterLeague() throws RiotApiException {
 
@@ -671,7 +712,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get master league
+	 * Get master tier leagues.
 	 * 
 	 * @param region
 	 *            The region of the leagues.
@@ -680,6 +721,7 @@ public class RiotApi {
 	 * @return A single league
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public League getMasterLeague(Region region, QueueType queueType) throws RiotApiException {
 
@@ -687,13 +729,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get master league
+	 * Get master tier leagues.
 	 * 
 	 * @param queueType
 	 *            Game queue type.
 	 * @return A single league
 	 * @see League
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public League getMasterLeague(QueueType queueType) throws RiotApiException {
 
@@ -701,7 +744,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a summary of player statistics for a given summoner
+	 * Get player stats summaries by summoner ID.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -712,6 +755,7 @@ public class RiotApi {
 	 * @return A summary of player statistics for the given summoner
 	 * @see PlayerStatsSummaryList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public PlayerStatsSummaryList getPlayerStatsSummary(Region region, Season season, long summonerId) throws RiotApiException {
 
@@ -719,7 +763,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a summary of player statistics for a given summoner
+	 * Get player stats summaries by summoner ID.
 	 *
 	 * @param summonerId
 	 *            ID of the summoner for which to retrieve player stats.
@@ -728,6 +772,7 @@ public class RiotApi {
 	 * @return A summary of player statistics for the given summoner
 	 * @see PlayerStatsSummaryList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public PlayerStatsSummaryList getPlayerStatsSummary(Season season, long summonerId) throws RiotApiException {
 
@@ -735,7 +780,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a summary of player statistics for a given summoner
+	 * Get player stats summaries by summoner ID.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -744,6 +789,7 @@ public class RiotApi {
 	 * @return A summary of player statistics for the given summoner
 	 * @see PlayerStatsSummaryList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public PlayerStatsSummaryList getPlayerStatsSummary(Region region, long summonerId) throws RiotApiException {
 
@@ -751,13 +797,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get a summary of player statistics for a given summoner
+	 * Get player stats summaries by summoner ID.
 	 *
 	 * @param summonerId
 	 *            ID of the summoner for which to retrieve player stats.
 	 * @return A summary of player statistics for the given summoner
 	 * @see PlayerStatsSummaryList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public PlayerStatsSummaryList getPlayerStatsSummary(long summonerId) throws RiotApiException {
 
@@ -765,7 +812,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the ranked statistics of a given summoner
+	 * Get ranked stats by summoner ID.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -776,6 +823,7 @@ public class RiotApi {
 	 * @return Ranked statistics of the given summoner
 	 * @see RankedStats
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RankedStats getRankedStats(Region region, Season season, long summonerId) throws RiotApiException {
 
@@ -783,7 +831,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the ranked statistics of a given summoner
+	 * Get ranked stats by summoner ID.
 	 *
 	 * @param summonerId
 	 *            ID of the summoner for which to retrieve ranked stats.
@@ -792,6 +840,7 @@ public class RiotApi {
 	 * @return Ranked statistics of the given summoner
 	 * @see RankedStats
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RankedStats getRankedStats(Season season, long summonerId) throws RiotApiException {
 
@@ -799,7 +848,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the ranked statistics of a given summoner
+	 * Get ranked stats by summoner ID.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -808,6 +857,7 @@ public class RiotApi {
 	 * @return Ranked statistics of the given summoner
 	 * @see RankedStats
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RankedStats getRankedStats(Region region, long summonerId) throws RiotApiException {
 
@@ -815,13 +865,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the ranked statistics of a given summoner
+	 * Get ranked stats by summoner ID.
 	 *
 	 * @param summonerId
 	 *            ID of the summoner for which to retrieve ranked stats.
 	 * @return Ranked statistics of the given summoner
 	 * @see RankedStats
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RankedStats getRankedStats(long summonerId) throws RiotApiException {
 
@@ -829,53 +880,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the mastery pages of multiple given summoners
-	 *
-	 * @param region
-	 *            Region where to retrieve the data.
-	 * @param summonerIds
-	 *            Comma-separated list of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
-	 * @return A map of mastery pages of the given summoners
-	 * @see MasteryPages
-	 * @throws RiotApiException
-	 */
-	public Map<String, MasteryPages> getMasteryPages(Region region, String summonerIds) throws RiotApiException {
-
-		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get the mastery pages of multiple given summoners
-	 *
-	 * @param summonerIds
-	 *            Comma-separated list of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
-	 * @return A map of mastery pages of the given summoners
-	 * @see MasteryPages
-	 * @throws RiotApiException
-	 */
-	public Map<String, MasteryPages> getMasteryPages(String summonerIds) throws RiotApiException {
-
-		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get the mastery pages of multiple given summoners
-	 *
-	 * @param region
-	 *            Region where to retrieve the data.
-	 * @param summonerIds
-	 *            List of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
-	 * @return A map of mastery pages of the given summoners
-	 * @see MasteryPages
-	 * @throws RiotApiException
-	 */
-	public Map<String, MasteryPages> getMasteryPages(Region region, long... summonerIds) throws RiotApiException {
-
-		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get the mastery pages of a given summoner
+	 * Get mastery pages for a given summoner ID.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -884,6 +889,7 @@ public class RiotApi {
 	 * @return A map of mastery pages of the given summoner
 	 * @see MasteryPages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MasteryPages getMasteryPages(Region region, long summonerId) throws RiotApiException {
 
@@ -891,27 +897,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the mastery pages of multiple given summoners
-	 *
-	 * @param summonerIds
-	 *            List of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
-	 * @return A map of mastery pages of the given summoners
-	 * @see MasteryPages
-	 * @throws RiotApiException
-	 */
-	public Map<String, MasteryPages> getMasteryPages(long... summonerIds) throws RiotApiException {
-
-		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get the mastery pages of a given summoner
+	 * Get mastery pages for a given summoner ID.
 	 *
 	 * @param summonerId
 	 *            Summoner ID associated with masteries to retrieve.
 	 * @return A map of mastery pages of the given summoner
 	 * @see MasteryPages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MasteryPages getMasteryPages(long summonerId) throws RiotApiException {
 
@@ -919,53 +912,71 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the rune pages of multiple given summoners
+	 * Get mastery pages mapped by summoner ID for a given list of summoner IDs.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
 	 * @param summonerIds
-	 *            Comma-separated list of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
-	 * @return A map of rune pages of the given summoners
-	 * @see RunePages
+	 *            Comma-separated list of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
+	 * @return A map of mastery pages of the given summoners
+	 * @see MasteryPages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
-	public Map<String, RunePages> getRunePages(Region region, String summonerIds) throws RiotApiException {
+	public Map<String, MasteryPages> getMasteryPages(Region region, String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
 	}
 
 	/**
-	 * Get the rune pages of multiple given summoners
+	 * Get mastery pages mapped by summoner ID for a given list of summoner IDs.
 	 *
 	 * @param summonerIds
-	 *            Comma-separated list of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
-	 * @return A map of rune pages of the given summoners
-	 * @see RunePages
+	 *            Comma-separated list of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
+	 * @return A map of mastery pages of the given summoners
+	 * @see MasteryPages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
-	public Map<String, RunePages> getRunePages(String summonerIds) throws RiotApiException {
+	public Map<String, MasteryPages> getMasteryPages(String summonerIds) throws RiotApiException {
 
-		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerIds);
+		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
 	}
 
 	/**
-	 * Get the rune pages of multiple given summoners
+	 * Get mastery pages mapped by summoner ID for a given list of summoner IDs.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
 	 * @param summonerIds
-	 *            List of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
-	 * @return A map of rune pages of the given summoners
-	 * @see RunePages
+	 *            List of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
+	 * @return A map of mastery pages of the given summoners
+	 * @see MasteryPages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
-	public Map<String, RunePages> getRunePages(Region region, long... summonerIds) throws RiotApiException {
+	public Map<String, MasteryPages> getMasteryPages(Region region, long... summonerIds) throws RiotApiException {
 
-		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
 	}
 
 	/**
-	 * Get the rune pages of a given summoner
+	 * Get mastery pages mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param summonerIds
+	 *            List of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
+	 * @return A map of mastery pages of the given summoners
+	 * @see MasteryPages
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, MasteryPages> getMasteryPages(long... summonerIds) throws RiotApiException {
+
+		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get rune pages for a given summoner ID.
 	 *
 	 * @param region
 	 *            Region where to retrieve the data.
@@ -974,6 +985,7 @@ public class RiotApi {
 	 * @return A map of rune pages of the given summoner
 	 * @see RunePages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RunePages getRunePages(Region region, long summonerId) throws RiotApiException {
 
@@ -981,13 +993,78 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the rune pages of multiple given summoners
+	 * Get rune pages for a given summoner ID.
+	 *
+	 * @param summonerId
+	 *            Summoner ID associated with runes to retrieve.
+	 * @return A map of rune pages of the given summoner
+	 * @see RunePages
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public RunePages getRunePages(long summonerId) throws RiotApiException {
+
+		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
+
+	/**
+	 * Get rune pages mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
+	 * @return A map of rune pages of the given summoners
+	 * @see RunePages
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, RunePages> getRunePages(Region region, String summonerIds) throws RiotApiException {
+
+		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get rune pages mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
+	 * @return A map of rune pages of the given summoners
+	 * @see RunePages
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, RunePages> getRunePages(String summonerIds) throws RiotApiException {
+
+		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get rune pages mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            List of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
+	 * @return A map of rune pages of the given summoners
+	 * @see RunePages
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, RunePages> getRunePages(Region region, long... summonerIds) throws RiotApiException {
+
+		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get rune pages mapped by summoner ID for a given list of summoner IDs.
 	 *
 	 * @param summonerIds
 	 *            List of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
 	 * @return A map of rune pages of the given summoners
 	 * @see RunePages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Map<String, RunePages> getRunePages(long... summonerIds) throws RiotApiException {
 
@@ -995,322 +1072,342 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get the rune pages of a given summoner
-	 *
-	 * @param summonerId
-	 *            Summoner ID associated with runes to retrieve.
-	 * @return A map of rune pages of the given summoner
-	 * @see RunePages
-	 * @throws RiotApiException
-	 */
-	public RunePages getRunePages(long summonerId) throws RiotApiException {
-
-		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
-	}
-
-    /**
-     * Get summoners by names
-     *
-     * @param region The desired region
-     * @param summonerNames The names of the desired summoners
-     * @return A map of desired summoners
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Map<String, Summoner> getSummonersByName(Region region, String summonerNames) throws RiotApiException {
-
-        return SummonerApi.getSummonersByName(region.getEndpoint(), region.getName(), getKey(), summonerNames);
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param summonerNames The names of the desired summoners
-     * @return A map of desired summoners
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Map<String, Summoner> getSummonersByName(String summonerNames) throws RiotApiException {
-    	
-        return SummonerApi.getSummonersByName(getEndpoint(), getRegion(), getKey(), summonerNames);
-    }
-
-    /**
-     * Get summoner by name
-     *
-     * @param region The desired region
-     * @param summonerName The name of the desired summoner
-     * @return The desired summoner
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Summoner getSummonerByName(Region region, String summonerName) throws RiotApiException {
-
-        Map<String, Summoner> summoners = SummonerApi.getSummonersByName(region.getEndpoint(), region.getName(), getKey(), summonerName);
-        Summoner summoner = summoners.entrySet().iterator().next().getValue();
-        return summoner;
-        
-    }
-
-    /**
-     * Get summoner by name
-     *
-     * @param summonerName The name of the desired summoner
-     * @return The desired summoner
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Summoner getSummonerByName(String summonerName) throws RiotApiException {
-    	
-    	Map<String, Summoner> summoners = SummonerApi.getSummonersByName(getEndpoint(), getRegion(), getKey(), summonerName);
-        Summoner summoner = summoners.entrySet().iterator().next().getValue();
-        return summoner;
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param region The desired region
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of desired summoners
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Map<String, Summoner> getSummonersById(Region region, long... summonerIds) throws RiotApiException {
-
-        return SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of desired summoners
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Map<String, Summoner> getSummonersById(long... summonerIds) throws RiotApiException {
-
-        return SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param region The desired region
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of desired summoners
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Map<String, Summoner> getSummonersById(Region region, String summonerIds) throws RiotApiException {
-
-        return SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of desired summoners
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Map<String, Summoner> getSummonersById(String summonerIds) throws RiotApiException {
-
-        return SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param region The desired region
-     * @param summonerId The ID of the desired summoner
-     * @return The desired summoner
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Summoner getSummonerById(Region region, long summonerId) throws RiotApiException {
-
-    	Map<String, Summoner> summoners = SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerId);
-    	Summoner summoner = summoners.entrySet().iterator().next().getValue();
-        return summoner;
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param summonerId The IDs of the desired summoners
-     * @return The desired summoner
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Summoner getSummonerById(long summonerId) throws RiotApiException {
-
-        Map<String, Summoner> summoners = SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerId);
-        Summoner summoner = summoners.entrySet().iterator().next().getValue();
-        return summoner;
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param region The desired region
-     * @param summonerId The IDs of the desired summoners
-     * @return The desired summoner
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Summoner getSummonerById(Region region, String summonerId) throws RiotApiException {
-
-        Map<String, Summoner> summoners = SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerId);
-        Summoner summoner = summoners.entrySet().iterator().next().getValue();
-        return summoner;
-    }
-
-    /**
-     * Get summoners by names
-     *
-     * @param region The desired region
-     * @param summonerId The IDs of the desired summoners
-     * @return The desired summoner
-     * @see Summoner
-     * @throws RiotApiException
-     */
-    public Summoner getSummonerById(String summonerId) throws RiotApiException {
-
-    	Map<String, Summoner> summoners = SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerId);
-    	Summoner summoner = summoners.entrySet().iterator().next().getValue();
-        return summoner;
-    }
-
-    /**
-     * Get summoner names by IDs
-     *
-     * @param region The desired region
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of desired summoner names
-     * @throws RiotApiException
-     */
-    public Map<String, String> getSummonerNames(Region region, long... summonerIds) throws RiotApiException {
-
-        return SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
-
-    /**
-     * Get summoner names by IDs
-     *
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of desired summoner names
-     * @throws RiotApiException
-     */
-    public Map<String, String> getSummonerNames(long... summonerIds) throws RiotApiException {
-
-        return SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
-
-    /**
-     * Get summoner names by IDs
-     *
-     * @param region The desired region
-     * @param summonerIds A comma separated list of IDs of the desired summoners
-     * @return A map of desired summoner names
-     * @throws RiotApiException
-     */
-    public Map<String, String> getSummonerNames(Region region, String summonerIds) throws RiotApiException {
-
-        return SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
-
-    /**
-     * Get summoner names by IDs
-     *
-     * @param summonerIds A comma separated list of IDs of the desired summoners
-     * @return A map of desired summoner names
-     * @throws RiotApiException
-     */
-    public Map<String, String> getSummonerNames(String summonerIds) throws RiotApiException {
-
-        return SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
-
-    /**
-     * Get summoner names by IDs
-     *
-     * @param region The desired region
-     * @param summonerId The IDs of the desired summoner
-     * @return The desired summoner name
-     * @throws RiotApiException
-     */
-    public String getSummonerName(Region region, long summonerId) throws RiotApiException {
-
-    	Map<String, String> summoners = SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerId);
-    	String name = summoners.entrySet().iterator().next().getValue();
-        return name;
-    }
-
-    /**
-     * Get summoner names by IDs
-     *
-     * @param region The desired region
-     * @param summonerId The IDs of the desired summoner
-     * @return The desired summoner name
-     * @throws RiotApiException
-     */
-    public String getSummonerName(long summonerId) throws RiotApiException {
-
-    	Map<String, String> summoners = SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerId);
-        String name = summoners.entrySet().iterator().next().getValue();
-        return name;
-    }
-
-    /**
-     * Get summoner names by IDs
-     *
-     * @param region The desired region
-     * @param summonerId The IDs of the desired summoner
-     * @return The desired summoner name
-     * @throws RiotApiException
-     */
-    public String getSummonerName(Region region, String summonerId) throws RiotApiException {
-
-        Map<String, String> summoners = SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerId);
-        String name = summoners.entrySet().iterator().next().getValue();
-        return name;
-    }
-
-    /**
-     * Get summoner names by IDs
-     *
-     * @param summonerId The ID of the desired summoner
-     * @return A map of desired summoner names
-     * @throws RiotApiException
-     */
-    public String getSummonerName(String summonerId) throws RiotApiException {
-
-    	Map<String, String> summoners = SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerId);
-    	String name = summoners.entrySet().iterator().next().getValue();
-        return name;
-    }
-
-	/**
-	 * Get teams for multiple summoners by summoner ID
+	 * Get a single summoner object for a given summoner name.
 	 *
 	 * @param region
-	 *            The region of the summoner.
-	 * @param summonerIds
-	 *            A list of summoner IDs. Maximum allowed at once is 10.
-	 * @return A map of the summoners' teams
-	 * @see Team
+	 *            Region where to retrieve the data.
+	 * @param summonerName
+	 *            Summoner name or standardized summoner name associated with summoner to retrieve.
+	 * @return The desired summoner
+	 * @see Summoner
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
-	public Map<String, List<Team>> getTeamsBySummonerIds(Region region, long... summonerIds) throws RiotApiException {
+	public Summoner getSummonerByName(Region region, String summonerName) throws RiotApiException {
 
-		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+		Map<String, Summoner> summoners = SummonerApi.getSummonersByName(region.getEndpoint(), region.getName(), getKey(), summonerName);
+		Summoner summoner = summoners.entrySet().iterator().next().getValue();
+		return summoner;
+
 	}
 
 	/**
-	 * Get teams for a summoner by summoner ID
+	 * Get a single summoner object for a given summoner name.
+	 *
+	 * @param summonerName
+	 *            Summoner name or standardized summoner name associated with summoner to retrieve.
+	 * @return The desired summoner
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Summoner getSummonerByName(String summonerName) throws RiotApiException {
+
+		Map<String, Summoner> summoners = SummonerApi.getSummonersByName(getEndpoint(), getRegion(), getKey(), summonerName);
+		Summoner summoner = summoners.entrySet().iterator().next().getValue();
+		return summoner;
+	}
+
+	/**
+	 * Get summoner objects mapped by standardized summoner name for a given list of summoner names.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerNames
+	 *            Comma-separated list of summoner names or standardized summoner names associated with summoners to retrieve. Maximum
+	 *            allowed at once is 40.
+	 * @return A map of desired summoners
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, Summoner> getSummonersByName(Region region, String summonerNames) throws RiotApiException {
+
+		return SummonerApi.getSummonersByName(region.getEndpoint(), region.getName(), getKey(), summonerNames);
+	}
+
+	/**
+	 * Get summoner objects mapped by standardized summoner name for a given list of summoner names.
+	 *
+	 * @param summonerNames
+	 *            Comma-separated list of summoner names or standardized summoner names associated with summoners to retrieve. Maximum
+	 *            allowed at once is 40.
+	 * @return A map of desired summoners
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, Summoner> getSummonersByName(String summonerNames) throws RiotApiException {
+
+		return SummonerApi.getSummonersByName(getEndpoint(), getRegion(), getKey(), summonerNames);
+	}
+
+	/**
+	 * Get a summoner objects for a given summoner ID.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            Summoner IDs associated with summoner to retrieve.
+	 * @return The desired summoner
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Summoner getSummonerById(Region region, long summonerId) throws RiotApiException {
+
+		Map<String, Summoner> summoners = SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		Summoner summoner = summoners.entrySet().iterator().next().getValue();
+		return summoner;
+	}
+
+	/**
+	 * Get a summoner objects for a given summoner ID.
+	 *
+	 * @param summonerId
+	 *            Summoner IDs associated with summoner to retrieve.
+	 * @return The desired summoner
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Summoner getSummonerById(long summonerId) throws RiotApiException {
+
+		Map<String, Summoner> summoners = SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerId);
+		Summoner summoner = summoners.entrySet().iterator().next().getValue();
+		return summoner;
+	}
+
+	/**
+	 * Get a summoner objects for a given summoner ID.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            Summoner IDs associated with summoner to retrieve.
+	 * @return The desired summoner
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Summoner getSummonerById(Region region, String summonerId) throws RiotApiException {
+
+		Map<String, Summoner> summoners = SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		Summoner summoner = summoners.entrySet().iterator().next().getValue();
+		return summoner;
+	}
+
+	/**
+	 * Get a summoner objects for a given summoner ID.
+	 *
+	 * @param summonerId
+	 *            Summoner IDs associated with summoner to retrieve.
+	 * @return The desired summoner
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Summoner getSummonerById(String summonerId) throws RiotApiException {
+
+		Map<String, Summoner> summoners = SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerId);
+		Summoner summoner = summoners.entrySet().iterator().next().getValue();
+		return summoner;
+	}
+
+	/**
+	 * Get summoner objects mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            List of summoner IDs associated with summoners to retrieve. Maximum allowed at once is 40.
+	 * @return A map of desired summoners
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, Summoner> getSummonersById(Region region, long... summonerIds) throws RiotApiException {
+
+		return SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get summoner objects mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param summonerIds
+	 *            List of summoner IDs associated with summoners to retrieve. Maximum allowed at once is 40.
+	 * @return A map of desired summoners
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, Summoner> getSummonersById(long... summonerIds) throws RiotApiException {
+
+		return SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get summoner objects mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with summoners to retrieve. Maximum allowed at once is 40.
+	 * @return A map of desired summoners
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, Summoner> getSummonersById(Region region, String summonerIds) throws RiotApiException {
+
+		return SummonerApi.getSummonersById(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get summoner objects mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with summoners to retrieve. Maximum allowed at once is 40.
+	 * @return A map of desired summoners
+	 * @see Summoner
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, Summoner> getSummonersById(String summonerIds) throws RiotApiException {
+
+		return SummonerApi.getSummonersById(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get summoner name for a given summoner ID.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            Summoner ID associated with summoner name to retrieve.
+	 * @return The desired summoner name
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public String getSummonerName(Region region, long summonerId) throws RiotApiException {
+
+		Map<String, String> summoners = SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		String name = summoners.entrySet().iterator().next().getValue();
+		return name;
+	}
+
+	/**
+	 * Get summoner name for a given summoner ID.
+	 *
+	 * @param summonerId
+	 *            Summoner ID associated with summoner name to retrieve.
+	 * @return The desired summoner name
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public String getSummonerName(long summonerId) throws RiotApiException {
+
+		Map<String, String> summoners = SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerId);
+		String name = summoners.entrySet().iterator().next().getValue();
+		return name;
+	}
+
+	/**
+	 * Get summoner name for a given summoner ID.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            Summoner ID associated with summoner name to retrieve.
+	 * @return The desired summoner name
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public String getSummonerName(Region region, String summonerId) throws RiotApiException {
+
+		Map<String, String> summoners = SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerId);
+		String name = summoners.entrySet().iterator().next().getValue();
+		return name;
+	}
+
+	/**
+	 * Get summoner name for a given summoner ID.
+	 *
+	 * @param summonerId
+	 *            Summoner ID associated with summoner name to retrieve.
+	 * @return A map of desired summoner names
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public String getSummonerName(String summonerId) throws RiotApiException {
+
+		Map<String, String> summoners = SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerId);
+		String name = summoners.entrySet().iterator().next().getValue();
+		return name;
+	}
+
+	/**
+	 * Get summoner names mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            List of summoner IDs associated with summoner names to retrieve. Maximum allowed at once is 40.
+	 * @return A map of desired summoner names
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, String> getSummonerNames(Region region, long... summonerIds) throws RiotApiException {
+
+		return SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get summoner names mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param summonerIds
+	 *            List of summoner IDs associated with summoner names to retrieve. Maximum allowed at once is 40.
+	 * @return A map of desired summoner names
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, String> getSummonerNames(long... summonerIds) throws RiotApiException {
+
+		return SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get summoner names mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with summoner names to retrieve. Maximum allowed at once is 40.
+	 * @return A map of desired summoner names
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, String> getSummonerNames(Region region, String summonerIds) throws RiotApiException {
+
+		return SummonerApi.getSummonerNames(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get summoner names mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with summoner names to retrieve. Maximum allowed at once is 40.
+	 * @return A map of desired summoner names
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, String> getSummonerNames(String summonerIds) throws RiotApiException {
+
+		return SummonerApi.getSummonerNames(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get teams for a given summoner ID.
 	 *
 	 * @param region
 	 *            The region of the summoner.
@@ -1319,6 +1416,7 @@ public class RiotApi {
 	 * @return A list of the summoner's teams
 	 * @see Team
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<Team> getTeamsBySummonerId(Region region, long summonerId) throws RiotApiException {
 
@@ -1326,27 +1424,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get teams for multiple summoners by summoner ID
-	 *
-	 * @param summonerIds
-	 *            A list of summoner IDs. Maximum allowed at once is 10.
-	 * @return A map of the summoners' teams
-	 * @see Team
-	 * @throws RiotApiException
-	 */
-	public Map<String, List<Team>> getTeamsBySummonerIds(long... summonerIds) throws RiotApiException {
-
-		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerIds);
-	}
-
-	/**
-	 * Get teams for a summoner by summoner ID
+	 * Get teams for a given summoner ID.
 	 *
 	 * @param summonerId
 	 *            A summoner ID
 	 * @return A list of the summoner's teams
 	 * @see Team
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<Team> getTeamsBySummonerId(long summonerId) throws RiotApiException {
 
@@ -1354,7 +1439,71 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get teams for multiple summoners by summoner ID
+	 * Get teams for a given summoner ID.
+	 *
+	 * @param region
+	 *            The region of the summoner.
+	 * @param summonerId
+	 *            Summoner ID
+	 * @return A list of the summoner's teams
+	 * @see Team
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public List<Team> getTeamsBySummonerId(Region region, String summonerId) throws RiotApiException {
+
+		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerId).get(summonerId);
+	}
+
+	/**
+	 * Get teams for a given summoner ID.
+	 *
+	 * @param summonerId
+	 *            A summoner ID
+	 * @return A list of the summoner's teams
+	 * @see Team
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public List<Team> getTeamsBySummonerId(String summonerId) throws RiotApiException {
+
+		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerId).get(summonerId);
+	}
+
+	/**
+	 * Get teams mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param region
+	 *            The region of the summoner.
+	 * @param summonerIds
+	 *            A list of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map of the summoners' teams
+	 * @see Team
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<Team>> getTeamsBySummonerIds(Region region, long... summonerIds) throws RiotApiException {
+
+		return TeamApi.getTeamsBySummonerIds(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get teams mapped by summoner ID for a given list of summoner IDs.
+	 *
+	 * @param summonerIds
+	 *            A list of summoner IDs. Maximum allowed at once is 10.
+	 * @return A map of the summoners' teams
+	 * @see Team
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public Map<String, List<Team>> getTeamsBySummonerIds(long... summonerIds) throws RiotApiException {
+
+		return TeamApi.getTeamsBySummonerIds(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get teams mapped by summoner ID for a given list of summoner IDs.
 	 *
 	 * @param region
 	 *            The region of the summoner.
@@ -1363,6 +1512,7 @@ public class RiotApi {
 	 * @return A map of the summoners' teams
 	 * @see Team
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Map<String, List<Team>> getTeamsBySummonerIds(Region region, String summonerIds) throws RiotApiException {
 
@@ -1370,13 +1520,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get teams for multiple summoners by summoner ID
+	 * Get teams mapped by summoner ID for a given list of summoner IDs.
 	 *
 	 * @param summonerIds
 	 *            Comma-separated list of summoner IDs
 	 * @return A map of the summoners' teams
 	 * @see Team
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Map<String, List<Team>> getTeamsBySummonerIds(String summonerIds) throws RiotApiException {
 
@@ -1384,7 +1535,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get match by ID
+	 * Retrieve match by match ID.
 	 *
 	 * @param region
 	 *            The region of the summoner.
@@ -1393,6 +1544,7 @@ public class RiotApi {
 	 * @return A map with match details
 	 * @see MatchDetail
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MatchDetail getMatch(Region region, long matchId) throws RiotApiException {
 
@@ -1400,13 +1552,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get match by ID
+	 * Retrieve match by match ID.
 	 *
 	 * @param matchId
 	 *            The ID of the match
 	 * @return A map with match details
 	 * @see MatchDetail
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MatchDetail getMatch(long matchId) throws RiotApiException {
 
@@ -1414,7 +1567,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get match by ID
+	 * Retrieve match by match ID.
 	 *
 	 * @param region
 	 *            The region of the summoner.
@@ -1425,6 +1578,7 @@ public class RiotApi {
 	 * @return A map with match details
 	 * @see MatchDetail
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MatchDetail getMatch(Region region, long matchId, boolean includeTimeline) throws RiotApiException {
 
@@ -1432,7 +1586,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get match by ID
+	 * Retrieve match by match ID.
 	 *
 	 * @param matchId
 	 *            The ID of the match.
@@ -1441,6 +1595,7 @@ public class RiotApi {
 	 * @return A map with match details
 	 * @see MatchDetail
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MatchDetail getMatch(long matchId, boolean includeTimeline) throws RiotApiException {
 
@@ -1448,7 +1603,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get match list by summonerID
+	 * Retrieve match list by summoner ID.
 	 *
 	 * @param region
 	 *            The region of the summoner.
@@ -1471,6 +1626,7 @@ public class RiotApi {
 	 * @return A list with matches
 	 * @see MatchList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MatchList getMatchList(Region region, long summonerId, String championIds, String rankedQueues, String seasons, long beginTime, long endTime,
 			int beginIndex, int endIndex) throws RiotApiException {
@@ -1480,7 +1636,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get match list by summonerID
+	 * Retrieve match list by summoner ID.
 	 *
 	 * @param The
 	 *            region of the summoner.
@@ -1489,6 +1645,7 @@ public class RiotApi {
 	 * @return A list with matches
 	 * @see MatchList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MatchList getMatchList(Region region, long summonerId) throws RiotApiException {
 
@@ -1496,7 +1653,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get match list by summonerID
+	 * Retrieve match list by summoner ID.
 	 *
 	 * @param summonerId
 	 *            The ID of the summoner.
@@ -1517,6 +1674,7 @@ public class RiotApi {
 	 * @return A list with matches
 	 * @see MatchList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MatchList getMatchList(long summonerId, String championIds, String rankedQueues, String seasons, long beginTime, long endTime, int beginIndex,
 			int endIndex) throws RiotApiException {
@@ -1526,21 +1684,22 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get match list by summonerID
+	 * Retrieve match list by summoner ID.
 	 *
 	 * @param summonerId
 	 *            The ID of the summoner.
 	 * @return A list with matches
 	 * @see MatchList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MatchList getMatchList(long summonerId) throws RiotApiException {
 
 		return MatchListApi.getMatchList(getEndpoint(), getRegion(), getKey(), summonerId, null, null, null, -1, -1, -1, -1);
 	}
-    
+
 	/**
-	 * Get current game info
+	 * Get current game information for the given summoner ID.
 	 * 
 	 * @param platformId
 	 *            The platform ID for which to fetch data.
@@ -1549,6 +1708,7 @@ public class RiotApi {
 	 * @return Current game info
 	 * @see CurrentGameInfo
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public CurrentGameInfo getCurrentGameInfo(PlatformId platformId, long summonerId) throws RiotApiException {
 
@@ -1556,13 +1716,31 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get featured games
+	 * Get current game information for the given summoner ID.
+	 * 
+	 * @param platformId
+	 *            The platform ID for which to fetch data.
+	 * @param summonerId
+	 *            The ID of the summoner.
+	 * @return Current game info
+	 * @see CurrentGameInfo
+	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
+	 */
+	public CurrentGameInfo getCurrentGameInfo(PlatformId platformId, String summonerId) throws RiotApiException {
+
+		return CurrentGameApi.getCurrentGameInfo(platformId, getKey(), summonerId);
+	}
+
+	/**
+	 * Get list of featured games.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return Featured games
 	 * @see FeaturedGames
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public FeaturedGames getFeaturedGames(Region region) throws RiotApiException {
 
@@ -1570,11 +1748,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get featured games
+	 * Get list of featured games.
 	 * 
 	 * @return Featured games
 	 * @see FeaturedGames
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public FeaturedGames getFeaturedGames() throws RiotApiException {
 
@@ -1582,7 +1761,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: champion list
+	 * Retrieves champion list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -1600,6 +1779,7 @@ public class RiotApi {
 	 * @return A list with champions
 	 * @see ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ChampionList getDataChampionList(Region region, String locale, String version, boolean dataById, ChampData... champData) throws RiotApiException {
 
@@ -1607,7 +1787,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: champion list
+	 * Retrieves champion list.
 	 * 
 	 * @param locale
 	 *            Locale code for returned data (e.g., en_US, es_ES). If not specified, the default locale for the region is used.
@@ -1623,6 +1803,7 @@ public class RiotApi {
 	 * @return A list with champions
 	 * @see ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ChampionList getDataChampionList(String locale, String version, boolean dataById, ChampData... champData) throws RiotApiException {
 
@@ -1630,13 +1811,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: champion list
+	 * Retrieves champion list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return A list with champions
 	 * @see ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ChampionList getDataChampionList(Region region) throws RiotApiException {
 
@@ -1644,11 +1826,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: champion list
+	 * Retrieves champion list.
 	 * 
 	 * @return A list with champions
 	 * @see ChampionList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ChampionList getDataChampionList() throws RiotApiException {
 
@@ -1656,7 +1839,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: champion
+	 * Retrieves a champion by its ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -1673,6 +1856,7 @@ public class RiotApi {
 	 * @return A single champion
 	 * @see Champion
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Static.Champion getDataChampion(Region region, int id, String locale, String version, ChampData... champData) throws RiotApiException {
 
@@ -1680,7 +1864,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: champion
+	 * Retrieves a champion by its ID.
 	 * 
 	 * @param id
 	 *            Champion ID
@@ -1695,6 +1879,7 @@ public class RiotApi {
 	 * @return A single champion
 	 * @see Champion
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Static.Champion getDataChampion(int id, String locale, String version, ChampData... champData) throws RiotApiException {
 
@@ -1702,7 +1887,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: champion
+	 * Retrieves a champion by its ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -1711,6 +1896,7 @@ public class RiotApi {
 	 * @return A single champion
 	 * @see Champion
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Static.Champion getDataChampion(Region region, int id) throws RiotApiException {
 
@@ -1718,13 +1904,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: champion
+	 * Retrieves a champion by its ID.
 	 * 
 	 * @param id
 	 *            Champion ID
 	 * @return A single champion
 	 * @see Champion
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public dto.Static.Champion getDataChampion(int id) throws RiotApiException {
 
@@ -1732,7 +1919,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: game map list
+	 * Retrieves map data.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -1744,6 +1931,7 @@ public class RiotApi {
 	 * @return A list of game maps
 	 * @see GameMapList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public GameMapList getDataGameMapList(Region region, String locale, String version) throws RiotApiException {
 
@@ -1751,7 +1939,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: game map list
+	 * Retrieves map data.
 	 * 
 	 * @param locale
 	 *            Locale code for returned data (e.g., en_US, es_ES). If not specified, the default locale for the region is used.
@@ -1761,6 +1949,7 @@ public class RiotApi {
 	 * @return A list of game maps
 	 * @see GameMapList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public GameMapList getDataGameMapList(String locale, String version) throws RiotApiException {
 
@@ -1768,13 +1957,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: game map list
+	 * Retrieves map data.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return A list of game maps
 	 * @see GameMapList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public GameMapList getDataGameMapList(Region region) throws RiotApiException {
 
@@ -1782,11 +1972,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: game map list
+	 * Retrieves map data.
 	 * 
 	 * @return A list of game maps
 	 * @see GameMapList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public GameMapList getDataGameMapList() throws RiotApiException {
 
@@ -1794,7 +1985,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: item list
+	 * Retrieves item list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -1809,6 +2000,7 @@ public class RiotApi {
 	 * @return A list of items
 	 * @see ItemList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ItemList getDataItemList(Region region, String locale, String version, ItemListData... itemListData) throws RiotApiException {
 
@@ -1816,7 +2008,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: item list
+	 * Retrieves item list.
 	 * 
 	 * @param locale
 	 *            Locale code for returned data (e.g., en_US, es_ES). If not specified, the default locale for the region is used.
@@ -1829,6 +2021,7 @@ public class RiotApi {
 	 * @return A list of items
 	 * @see ItemList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ItemList getDataItemList(String locale, String version, ItemListData... itemListData) throws RiotApiException {
 
@@ -1836,13 +2029,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: item list
+	 * Retrieves item list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return A list of items
 	 * @see ItemList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ItemList getDataItemList(Region region) throws RiotApiException {
 
@@ -1850,11 +2044,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: item list
+	 * Retrieves item list.
 	 * 
 	 * @return A list of items
 	 * @see ItemList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ItemList getDataItemList() throws RiotApiException {
 
@@ -1862,7 +2057,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: item
+	 * Retrieves item by its unique ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -1879,6 +2074,7 @@ public class RiotApi {
 	 * @return A single item
 	 * @see Item
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Item getDataItem(Region region, int id, String locale, String version, ItemData... itemData) throws RiotApiException {
 
@@ -1886,7 +2082,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: item
+	 * Retrieves item by its unique ID.
 	 * 
 	 * @param id
 	 *            Item ID
@@ -1901,6 +2097,7 @@ public class RiotApi {
 	 * @return A single item
 	 * @see Item
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Item getDataItem(int id, String locale, String version, ItemData... itemData) throws RiotApiException {
 
@@ -1908,7 +2105,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: item
+	 * Retrieves item by its unique ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -1917,6 +2114,7 @@ public class RiotApi {
 	 * @return A single item
 	 * @see Item
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Item getDataItem(Region region, int id) throws RiotApiException {
 
@@ -1924,13 +2122,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: item
+	 * Retrieves item by its unique ID.
 	 * 
 	 * @param id
 	 *            Item ID
 	 * @return A single item
 	 * @see Item
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Item getDataItem(int id) throws RiotApiException {
 
@@ -1938,12 +2137,13 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: languages
+	 * Retrieve supported languages data.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return A list with languages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<String> getDataLanguages(Region region) throws RiotApiException {
 
@@ -1951,10 +2151,11 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: languages
+	 * Retrieve supported languages data.
 	 * 
 	 * @return A list with languages
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<String> getDataLanguages() throws RiotApiException {
 
@@ -1962,7 +2163,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: language strings
+	 * Retrieve language strings data.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -1974,6 +2175,7 @@ public class RiotApi {
 	 * @return Language strings
 	 * @see LanguageStrings
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public LanguageStrings getDataLanguageStrings(Region region, String locale, String version) throws RiotApiException {
 
@@ -1981,7 +2183,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: language strings
+	 * Retrieve language strings data.
 	 * 
 	 * @param locale
 	 *            Locale code for returned data (e.g., en_US, es_ES). If not specified, the default locale for the region is used.
@@ -1991,6 +2193,7 @@ public class RiotApi {
 	 * @return Language strings
 	 * @see LanguageStrings
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public LanguageStrings getDataLanguageStrings(String locale, String version) throws RiotApiException {
 
@@ -1998,13 +2201,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: language strings
+	 * Retrieve language strings data.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return Language strings
 	 * @see LanguageStrings
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public LanguageStrings getDataLanguageStrings(Region region) throws RiotApiException {
 
@@ -2012,11 +2216,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: language strings
+	 * Retrieve language strings data.
 	 * 
 	 * @return Language strings
 	 * @see LanguageStrings
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public LanguageStrings getDataLanguageStrings() throws RiotApiException {
 
@@ -2024,7 +2229,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: mastery list
+	 * Retrieves mastery list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2039,6 +2244,7 @@ public class RiotApi {
 	 * @return A list with masteries
 	 * @see MasteryList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MasteryList getDataMasteryList(Region region, String locale, String version, MasteryListData... masteryListData) throws RiotApiException {
 
@@ -2046,7 +2252,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: mastery list
+	 * Retrieves mastery list.
 	 * 
 	 * @param locale
 	 *            Locale code for returned data (e.g., en_US, es_ES). If not specified, the default locale for the region is used.
@@ -2059,6 +2265,7 @@ public class RiotApi {
 	 * @return A list with masteries
 	 * @see MasteryList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MasteryList getDataMasteryList(String locale, String version, MasteryListData... masteryListData) throws RiotApiException {
 
@@ -2066,13 +2273,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: mastery list
+	 * Retrieves mastery list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return A list with masteries
 	 * @see MasteryList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MasteryList getDataMasteryList(Region region) throws RiotApiException {
 
@@ -2080,11 +2288,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: mastery list
+	 * Retrieves mastery list.
 	 * 
 	 * @return A list with masteries
 	 * @see MasteryList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public MasteryList getDataMasteryList() throws RiotApiException {
 
@@ -2092,7 +2301,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: mastery
+	 * Retrieves mastery item by its unique ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2109,6 +2318,7 @@ public class RiotApi {
 	 * @return A single mastery
 	 * @see Mastery
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Mastery getDataMastery(Region region, int id, String locale, String version, MasteryData... masteryData) throws RiotApiException {
 
@@ -2116,7 +2326,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: mastery
+	 * Retrieves mastery item by its unique ID.
 	 * 
 	 * @param id
 	 *            Mastery ID
@@ -2131,6 +2341,7 @@ public class RiotApi {
 	 * @return A single mastery
 	 * @see Mastery
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Mastery getDataMastery(int id, String locale, String version, MasteryData... masteryData) throws RiotApiException {
 
@@ -2138,7 +2349,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: mastery
+	 * Retrieves mastery item by its unique ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2147,6 +2358,7 @@ public class RiotApi {
 	 * @return A single mastery
 	 * @see Mastery
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Mastery getDataMastery(Region region, int id) throws RiotApiException {
 
@@ -2154,13 +2366,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: mastery
+	 * Retrieves mastery item by its unique ID.
 	 * 
 	 * @param id
 	 *            Mastery ID
 	 * @return A single mastery
 	 * @see Mastery
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Mastery getDataMastery(int id) throws RiotApiException {
 
@@ -2168,13 +2381,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: realm
+	 * Retrieve realm data.
 	 * 
 	 * @param region
 	 *            Region corresponding to data to retrieve.
 	 * @return A single realm
 	 * @see Realm
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Realm getDataRealm(Region region) throws RiotApiException {
 
@@ -2182,11 +2396,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: realm
+	 * Retrieve realm data.
 	 * 
 	 * @return A single realm
 	 * @see Realm
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Realm getDataRealm() throws RiotApiException {
 
@@ -2194,7 +2409,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: rune list
+	 * Retrieves rune list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2209,6 +2424,7 @@ public class RiotApi {
 	 * @return A list with runes
 	 * @see RuneList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RuneList getDataRuneList(Region region, String locale, String version, RuneListData... runeListData) throws RiotApiException {
 
@@ -2216,7 +2432,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: rune list
+	 * Retrieves rune list.
 	 * 
 	 * @param locale
 	 *            Locale code for returned data (e.g., en_US, es_ES). If not specified, the default locale for the region is used.
@@ -2229,6 +2445,7 @@ public class RiotApi {
 	 * @return A list with runes
 	 * @see RuneList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RuneList getDataRuneList(String locale, String version, RuneListData... runeListData) throws RiotApiException {
 
@@ -2236,13 +2453,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: rune list
+	 * Retrieves rune list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return A list with runes
 	 * @see RuneList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RuneList getDataRuneList(Region region) throws RiotApiException {
 
@@ -2250,11 +2468,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: rune list
+	 * Retrieves rune list.
 	 * 
 	 * @return A list with runes
 	 * @see RuneList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public RuneList getDataRuneList() throws RiotApiException {
 
@@ -2262,7 +2481,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: rune
+	 * Retrieves rune by its unique ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2279,6 +2498,7 @@ public class RiotApi {
 	 * @return A single rune
 	 * @see Rune
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Rune getDataRune(Region region, int id, String locale, String version, RuneData... runeData) throws RiotApiException {
 
@@ -2286,7 +2506,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: rune
+	 * Retrieves rune by its unique ID.
 	 * 
 	 * @param id
 	 *            Rune ID
@@ -2301,6 +2521,7 @@ public class RiotApi {
 	 * @return A single rune
 	 * @see Rune
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Rune getDataRune(int id, String locale, String version, RuneData... runeData) throws RiotApiException {
 
@@ -2308,7 +2529,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: rune
+	 * Retrieves rune by its unique ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2317,6 +2538,7 @@ public class RiotApi {
 	 * @return A single rune
 	 * @see Rune
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Rune getDataRune(Region region, int id) throws RiotApiException {
 
@@ -2324,13 +2546,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: rune
+	 * Retrieves rune by its unique ID.
 	 * 
 	 * @param id
 	 *            Rune ID
 	 * @return A single rune
 	 * @see Rune
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public Rune getDataRune(int id) throws RiotApiException {
 
@@ -2338,7 +2561,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: summoner spell list
+	 * Retrieves summoner spell list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2356,6 +2579,7 @@ public class RiotApi {
 	 * @return A list with summoner spells
 	 * @see SummonerSpellList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public SummonerSpellList getDataSummonerSpellList(Region region, String locale, String version, boolean dataById, SpellData... spellData)
 			throws RiotApiException {
@@ -2364,7 +2588,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: summoner spell list
+	 * Retrieves summoner spell list.
 	 * 
 	 * @param locale
 	 *            Locale code for returned data (e.g., en_US, es_ES). If not specified, the default locale for the region is used.
@@ -2380,6 +2604,7 @@ public class RiotApi {
 	 * @return A list with summoner spells
 	 * @see SummonerSpellList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public SummonerSpellList getDataSummonerSpellList(String locale, String version, boolean dataById, SpellData... spellData) throws RiotApiException {
 
@@ -2387,13 +2612,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: summoner spell list
+	 * Retrieves summoner spell list.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return A list with summoner spells
 	 * @see SummonerSpellList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public SummonerSpellList getDataSummonerSpellList(Region region) throws RiotApiException {
 
@@ -2401,11 +2627,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: summoner spell list
+	 * Retrieves summoner spell list.
 	 * 
 	 * @return A list with summoner spells
 	 * @see SummonerSpellList
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public SummonerSpellList getDataSummonerSpellList() throws RiotApiException {
 
@@ -2413,7 +2640,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: summoner spell
+	 * Retrieves summoner spell by its unique ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2430,6 +2657,7 @@ public class RiotApi {
 	 * @return A single summoner spell
 	 * @see SummonerSpell
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public SummonerSpell getDataSummonerSpell(Region region, int id, String locale, String version, SpellData... spellData) throws RiotApiException {
 
@@ -2437,7 +2665,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: summoner spell
+	 * Retrieves summoner spell by its unique ID.
 	 * 
 	 * @param id
 	 *            Summoner spell ID
@@ -2452,6 +2680,7 @@ public class RiotApi {
 	 * @return A single summoner spell
 	 * @see SummonerSpell
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public SummonerSpell getDataSummonerSpell(int id, String locale, String version, SpellData... spellData) throws RiotApiException {
 
@@ -2459,7 +2688,7 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: summoner spell
+	 * Retrieves summoner spell by its unique ID.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
@@ -2468,6 +2697,7 @@ public class RiotApi {
 	 * @return A single summoner spell
 	 * @see SummonerSpell
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public SummonerSpell getDataSummonerSpell(Region region, int id) throws RiotApiException {
 
@@ -2475,13 +2705,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: summoner spell
+	 * Retrieves summoner spell by its unique ID.
 	 * 
 	 * @param id
 	 *            Summoner spell ID
 	 * @return A single summoner spell
 	 * @see SummonerSpell
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public SummonerSpell getDataSummonerSpell(int id) throws RiotApiException {
 
@@ -2489,12 +2720,13 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: versions
+	 * Retrieve version data.
 	 * 
 	 * @param region
 	 *            Region from which to retrieve data.
 	 * @return A list with versions
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<String> getDataVersions(Region region) throws RiotApiException {
 
@@ -2502,10 +2734,11 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get static data: versions
+	 * Retrieve version data.
 	 * 
 	 * @return A list with versions
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<String> getDataVersions() throws RiotApiException {
 
@@ -2513,11 +2746,12 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get status data: shard list
+	 * Get shard list.
 	 * 
 	 * @return Status for a list of shards
 	 * @see Shard
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public List<Shard> getShards() throws RiotApiException {
 
@@ -2525,13 +2759,14 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get status data: shard
+	 * Get shard status. Returns the data available on the status.leagueoflegends.com website for the given region.
 	 * 
 	 * @param region
 	 *            The region for which to fetch data.
 	 * @return Status for a single shard
 	 * @see ShardStatus
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ShardStatus getShardStatus(Region region) throws RiotApiException {
 
@@ -2539,91 +2774,95 @@ public class RiotApi {
 	}
 
 	/**
-	 * Get status data: shard
+	 * Get shard status. Returns the data available on the status.leagueoflegends.com website for the given region.
 	 * 
 	 * @return Status for a single shard
 	 * @see ShardStatus
 	 * @throws RiotApiException
+	 *             if the API returns an error or unparsable result
 	 */
 	public ShardStatus getShardStatus() throws RiotApiException {
 
 		return StatusApi.getShardStatus(getRegion());
 	}
-	 
-    /**
-     * Get the currently set season
-     *
-     * @return The currently set season
-     */
-    public String getSeason() {
-    	if(season == null){
-    		return null;
-    	}
-        return season.getName();
-    }
 
-    /**
-     * Get the currently set API key
-     *
-     * @return The currently set API key
-     */
-    public String getKey() {
-        return key;
-    }
+	/**
+	 * Get the currently set season
+	 *
+	 * @return The currently set season
+	 */
+	public String getSeason() {
+		if (season == null) {
+			return null;
+		}
+		return season.getName();
+	}
 
-    /**
-     * Get the currently set region
-     *
-     * @return The currently set region
-     * @throws  
-     */
-    public String getRegion() {
-        return region.getName();
-    }
+	/**
+	 * Get the currently set API key
+	 *
+	 * @return The currently set API key
+	 */
+	public String getKey() {
+		return key;
+	}
 
-    /**
-     * Set the season
-     *
-     * @param season The season to set
-     */
-    public void setSeason(Season season) {
-        this.season = season;
-    }
+	/**
+	 * Get the currently set region
+	 *
+	 * @return The currently set region
+	 * @throws
+	 */
+	public String getRegion() {
+		return region.getName();
+	}
 
-    /**
-     * Set the API key
-     *
-     * @param key The API key to set
-     */
-    public void setKey(String key) {
-        this.key = key;
-    }
+	/**
+	 * Set the season
+	 *
+	 * @param season
+	 *            The season to set
+	 */
+	public void setSeason(Season season) {
+		this.season = season;
+	}
 
-    /**
-     * Set the region
-     *
-     * @param region The region to set
-     */
-    public void setRegion(Region region) {
-        this.region = region;
-        setEndpoint();
-    }
+	/**
+	 * Set the API key
+	 *
+	 * @param key
+	 *            The API key to set
+	 */
+	public void setKey(String key) {
+		this.key = key;
+	}
 
-    /**
-     * Get the base URL for all API requests
-     *
-     * @return The base URL for all API requests
-     */
-    public String getEndpoint() {
-        return endpoint;
-    }
+	/**
+	 * Set the region
+	 *
+	 * @param region
+	 *            The region to set
+	 */
+	public void setRegion(Region region) {
+		this.region = region;
+		setEndpoint();
+	}
 
-    private void setEndpoint() {
-        this.endpoint = region.getEndpoint();
-    }
-    
-    @Override
-    public RiotApi clone() {
-    	return new RiotApi(this.key, this.region);
-    }
+	/**
+	 * Get the base URL for all API requests
+	 *
+	 * @return The base URL for all API requests
+	 */
+	public String getEndpoint() {
+		return endpoint;
+	}
+
+	private void setEndpoint() {
+		this.endpoint = region.getEndpoint();
+	}
+
+	@Override
+	public RiotApi clone() {
+		return new RiotApi(this.key, this.region);
+	}
 }

--- a/src/main/java/riotapi/RiotApi.java
+++ b/src/main/java/riotapi/RiotApi.java
@@ -704,279 +704,313 @@ public class RiotApi {
 		return LeagueApi.getMasterLeague(getEndpoint(), getRegion(), getKey(), queueType);
 	}
 
-    /**
-     * Get a summary of player statistics for a given summoner
-     *
-     * @param region The desired region
-     * @param summonerId The ID of the desired summoner
-     * @param season The desired season
-     * @return A summary of player statistics for the given summoner
-     * @see PlayerStatsSummaryList
-     * @throws RiotApiException
-     */
-    public PlayerStatsSummaryList getPlayerStatsSummary(Region region, Season season, long summonerId) throws RiotApiException {
+	/**
+	 * Get a summary of player statistics for a given summoner
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve player stats.
+	 * @param season
+	 *            If specified, stats for the given season are returned. Otherwise, stats for the current season are returned.
+	 * @return A summary of player statistics for the given summoner
+	 * @see PlayerStatsSummaryList
+	 * @throws RiotApiException
+	 */
+	public PlayerStatsSummaryList getPlayerStatsSummary(Region region, Season season, long summonerId) throws RiotApiException {
 
-        return StatsApi.getPlayerStatsSummary(region.getEndpoint(), region.getName(), season.getName(), getKey(), summonerId);
-    }
+		return StatsApi.getPlayerStatsSummary(region.getEndpoint(), region.getName(), season.getName(), getKey(), summonerId);
+	}
 
-    /**
-     * Get a summary of player statistics for a given summoner
-     *
-     * @param summonerId The ID of the desired summoner
-     * @param season The desired season
-     * @return A summary of player statistics for the given summoner
-     * @see PlayerStatsSummaryList
-     * @throws RiotApiException
-     */
-    public PlayerStatsSummaryList getPlayerStatsSummary(Season season, long summonerId) throws RiotApiException {
+	/**
+	 * Get a summary of player statistics for a given summoner
+	 *
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve player stats.
+	 * @param season
+	 *            If specified, stats for the given season are returned. Otherwise, stats for the current season are returned.
+	 * @return A summary of player statistics for the given summoner
+	 * @see PlayerStatsSummaryList
+	 * @throws RiotApiException
+	 */
+	public PlayerStatsSummaryList getPlayerStatsSummary(Season season, long summonerId) throws RiotApiException {
 
-        return StatsApi.getPlayerStatsSummary(getEndpoint(), getRegion(), season.getName(), getKey(), summonerId);
-    }
+		return StatsApi.getPlayerStatsSummary(getEndpoint(), getRegion(), season.getName(), getKey(), summonerId);
+	}
 
-    /**
-     * Get a summary of player statistics for a given summoner
-     *
-     * @param region The desired region
-     * @param summonerId The ID of the desired summoner
-     * @return A summary of player statistics for the given summoner
-     * @see PlayerStatsSummaryList
-     * @throws RiotApiException
-     */
-    public PlayerStatsSummaryList getPlayerStatsSummary(Region region, long summonerId) throws RiotApiException {
+	/**
+	 * Get a summary of player statistics for a given summoner
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve player stats.
+	 * @return A summary of player statistics for the given summoner
+	 * @see PlayerStatsSummaryList
+	 * @throws RiotApiException
+	 */
+	public PlayerStatsSummaryList getPlayerStatsSummary(Region region, long summonerId) throws RiotApiException {
 
-        return StatsApi.getPlayerStatsSummary(region.getEndpoint(), region.getName(), getSeason(), getKey(), summonerId);
-    }
+		return StatsApi.getPlayerStatsSummary(region.getEndpoint(), region.getName(), getSeason(), getKey(), summonerId);
+	}
 
-    /**
-     * Get a summary of player statistics for a given summoner
-     *
-     * @param summonerId The ID of the desired summoner
-     * @return A summary of player statistics for the given summoner
-     * @see PlayerStatsSummaryList
-     * @throws RiotApiException
-     */
-    public PlayerStatsSummaryList getPlayerStatsSummary(long summonerId) throws RiotApiException {
+	/**
+	 * Get a summary of player statistics for a given summoner
+	 *
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve player stats.
+	 * @return A summary of player statistics for the given summoner
+	 * @see PlayerStatsSummaryList
+	 * @throws RiotApiException
+	 */
+	public PlayerStatsSummaryList getPlayerStatsSummary(long summonerId) throws RiotApiException {
 
-        return StatsApi.getPlayerStatsSummary(getEndpoint(), getRegion(), getSeason(), getKey(), summonerId);
-    }
+		return StatsApi.getPlayerStatsSummary(getEndpoint(), getRegion(), getSeason(), getKey(), summonerId);
+	}
 
-    /**
-     * Get the ranked statistics of a given summoner
-     *
-     * @param region The desired region
-     * @param summonerId The ID of the desired summoner
-     * @param season The desired season
-     * @return Ranked statistics of the given summoner
-     * @see RankedStats
-     * @throws RiotApiException
-     */
-    public RankedStats getRankedStats(Region region, Season season, long summonerId) throws RiotApiException {
+	/**
+	 * Get the ranked statistics of a given summoner
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve ranked stats.
+	 * @param season
+	 *            If specified, stats for the given season are returned. Otherwise, stats for the current season are returned.
+	 * @return Ranked statistics of the given summoner
+	 * @see RankedStats
+	 * @throws RiotApiException
+	 */
+	public RankedStats getRankedStats(Region region, Season season, long summonerId) throws RiotApiException {
 
-        return StatsApi.getRankedStats(region.getEndpoint(), region.getName(), season.getName(), getKey(), summonerId);
-    }
+		return StatsApi.getRankedStats(region.getEndpoint(), region.getName(), season.getName(), getKey(), summonerId);
+	}
 
-    /**
-     * Get the ranked statistics of a given summoner
-     *
-     * @param summonerId The ID of the desired summoner
-     * @param season The desired season
-     * @return Ranked statistics of the given summoner
-     * @see RankedStats
-     * @throws RiotApiException
-     */
-    public RankedStats getRankedStats(Season season, long summonerId) throws RiotApiException {
+	/**
+	 * Get the ranked statistics of a given summoner
+	 *
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve ranked stats.
+	 * @param season
+	 *            If specified, stats for the given season are returned. Otherwise, stats for the current season are returned.
+	 * @return Ranked statistics of the given summoner
+	 * @see RankedStats
+	 * @throws RiotApiException
+	 */
+	public RankedStats getRankedStats(Season season, long summonerId) throws RiotApiException {
 
-        return StatsApi.getRankedStats(getEndpoint(), getRegion(), season.getName(), getKey(), summonerId);
-    }
+		return StatsApi.getRankedStats(getEndpoint(), getRegion(), season.getName(), getKey(), summonerId);
+	}
 
-    /**
-     * Get the ranked statistics of a given summoner
-     *
-     * @param region The desired region
-     * @param summonerId The ID of the desired summoner
-     * @return Ranked statistics of the given summoner
-     * @see RankedStats
-     * @throws RiotApiException
-     */
-    public RankedStats getRankedStats(Region region, long summonerId) throws RiotApiException {
+	/**
+	 * Get the ranked statistics of a given summoner
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve ranked stats.
+	 * @return Ranked statistics of the given summoner
+	 * @see RankedStats
+	 * @throws RiotApiException
+	 */
+	public RankedStats getRankedStats(Region region, long summonerId) throws RiotApiException {
 
-        return StatsApi.getRankedStats(region.getEndpoint(), region.getName(), getSeason(), getKey(), summonerId);
-    }
+		return StatsApi.getRankedStats(region.getEndpoint(), region.getName(), getSeason(), getKey(), summonerId);
+	}
 
-    /**
-     * Get the ranked statistics of a given summoner
-     *
-     * @param summonerId The ID of the desired summoner
-     * @return Ranked statistics of the given summoner
-     * @see RankedStats
-     * @throws RiotApiException
-     */
-    public RankedStats getRankedStats(long summonerId) throws RiotApiException {
+	/**
+	 * Get the ranked statistics of a given summoner
+	 *
+	 * @param summonerId
+	 *            ID of the summoner for which to retrieve ranked stats.
+	 * @return Ranked statistics of the given summoner
+	 * @see RankedStats
+	 * @throws RiotApiException
+	 */
+	public RankedStats getRankedStats(long summonerId) throws RiotApiException {
 
-        return StatsApi.getRankedStats(getEndpoint(), getRegion(), getSeason(), getKey(), summonerId);
-    }
+		return StatsApi.getRankedStats(getEndpoint(), getRegion(), getSeason(), getKey(), summonerId);
+	}
 
-    /**
-     * Get the mastery pages of a given summoner
-     *
-     * @param region The desired region
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of mastery pages of the given summoners
-     * @see MasteryPages
-     * @throws RiotApiException
-     */
-    public Map<String, MasteryPages> getMasteryPages(Region region, String summonerIds) throws RiotApiException {
+	/**
+	 * Get the mastery pages of multiple given summoners
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
+	 * @return A map of mastery pages of the given summoners
+	 * @see MasteryPages
+	 * @throws RiotApiException
+	 */
+	public Map<String, MasteryPages> getMasteryPages(Region region, String summonerIds) throws RiotApiException {
 
-        return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
+		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
 
-    /**
-     * Get the mastery pages of a given summoner
-     *
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of mastery pages of the given summoners
-     * @see MasteryPages
-     * @throws RiotApiException
-     */
-    public Map<String, MasteryPages> getMasteryPages(String summonerIds) throws RiotApiException {
+	/**
+	 * Get the mastery pages of multiple given summoners
+	 *
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
+	 * @return A map of mastery pages of the given summoners
+	 * @see MasteryPages
+	 * @throws RiotApiException
+	 */
+	public Map<String, MasteryPages> getMasteryPages(String summonerIds) throws RiotApiException {
 
-        return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
+		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
 
-    /**
-     * Get the mastery pages of given summoners
-     *
-     * @param region The desired region
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of mastery pages of the given summoners
-     * @see MasteryPages
-     * @throws RiotApiException
-     */
-    public Map<String, MasteryPages> getMasteryPages(Region region, long... summonerIds) throws RiotApiException {
+	/**
+	 * Get the mastery pages of multiple given summoners
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            List of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
+	 * @return A map of mastery pages of the given summoners
+	 * @see MasteryPages
+	 * @throws RiotApiException
+	 */
+	public Map<String, MasteryPages> getMasteryPages(Region region, long... summonerIds) throws RiotApiException {
 
-        return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
-    
-    /**
-     * Get the mastery pages of a given summoner
-     *
-     * @param region The desired region
-     * @param summonerId The ID of the desired summoner
-     * @return A map of mastery pages of the given summoner
-     * @see MasteryPages
-     * @throws RiotApiException
-     */
-    public MasteryPages getMasteryPages(Region region, long summonerId) throws RiotApiException {
+		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
 
-        return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
-    }
+	/**
+	 * Get the mastery pages of a given summoner
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            Summoner ID associated with masteries to retrieve.
+	 * @return A map of mastery pages of the given summoner
+	 * @see MasteryPages
+	 * @throws RiotApiException
+	 */
+	public MasteryPages getMasteryPages(Region region, long summonerId) throws RiotApiException {
 
-    /**
-     * Get the mastery pages of a given summoner
-     *
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of mastery pages of the given summoners
-     * @see MasteryPages
-     * @throws RiotApiException
-     */
-    public Map<String, MasteryPages> getMasteryPages(long... summonerIds) throws RiotApiException {
+		return SummonerApi.getMasteryPages(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
 
-        return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
-    
-    /**
-     * Get the mastery pages of a given summoner
-     *
-     * @param summonerId The IDs of the desired summoner
-     * @return A map of mastery pages of the given summoner
-     * @see MasteryPages
-     * @throws RiotApiException
-     */
-    public MasteryPages getMasteryPages(long summonerId) throws RiotApiException {
+	/**
+	 * Get the mastery pages of multiple given summoners
+	 *
+	 * @param summonerIds
+	 *            List of summoner IDs associated with masteries to retrieve. Maximum allowed at once is 40.
+	 * @return A map of mastery pages of the given summoners
+	 * @see MasteryPages
+	 * @throws RiotApiException
+	 */
+	public Map<String, MasteryPages> getMasteryPages(long... summonerIds) throws RiotApiException {
 
-        return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
-    }
+		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
 
-    /**
-     * Get the rune pages of a given summoner
-     *
-     * @param region The desired region
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of rune pages of the given summoners
-     * @see RunePages
-     * @throws RiotApiException
-     */
-    public Map<String, RunePages> getRunePages(Region region, String summonerIds) throws RiotApiException {
+	/**
+	 * Get the mastery pages of a given summoner
+	 *
+	 * @param summonerId
+	 *            Summoner ID associated with masteries to retrieve.
+	 * @return A map of mastery pages of the given summoner
+	 * @see MasteryPages
+	 * @throws RiotApiException
+	 */
+	public MasteryPages getMasteryPages(long summonerId) throws RiotApiException {
 
-        return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
+		return SummonerApi.getMasteryPages(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
 
-    /**
-     * Get the rune pages of a given summoner
-     *
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of rune pages of the given summoners
-     * @see RunePages
-     * @throws RiotApiException
-     */
-    public Map<String, RunePages> getRunePages(String summonerIds) throws RiotApiException {
+	/**
+	 * Get the rune pages of multiple given summoners
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
+	 * @return A map of rune pages of the given summoners
+	 * @see RunePages
+	 * @throws RiotApiException
+	 */
+	public Map<String, RunePages> getRunePages(Region region, String summonerIds) throws RiotApiException {
 
-        return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
+		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
 
-    /**
-     * Get the rune pages of a given summoners
-     *
-     * @param region The desired region
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of rune pages of the given summoners
-     * @see RunePages
-     * @throws RiotApiException
-     */
-    public Map<String, RunePages> getRunePages(Region region, long... summonerIds) throws RiotApiException {
+	/**
+	 * Get the rune pages of multiple given summoners
+	 *
+	 * @param summonerIds
+	 *            Comma-separated list of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
+	 * @return A map of rune pages of the given summoners
+	 * @see RunePages
+	 * @throws RiotApiException
+	 */
+	public Map<String, RunePages> getRunePages(String summonerIds) throws RiotApiException {
 
-        return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
-    }
-    
-    /**
-     * Get the rune pages of a given summoner
-     *
-     * @param region The desired region
-     * @param summonerId The IDs of the desired summoner
-     * @return A map of rune pages of the given summoner
-     * @see RunePages
-     * @throws RiotApiException
-     */
-    public RunePages getRunePages(Region region, long summonerId) throws RiotApiException {
+		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
 
-        return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
-    }
+	/**
+	 * Get the rune pages of multiple given summoners
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerIds
+	 *            List of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
+	 * @return A map of rune pages of the given summoners
+	 * @see RunePages
+	 * @throws RiotApiException
+	 */
+	public Map<String, RunePages> getRunePages(Region region, long... summonerIds) throws RiotApiException {
 
-    /**
-     * Get the rune pages of a given summoners
-     *
-     * @param summonerIds The IDs of the desired summoners
-     * @return A map of rune pages of the given summoners
-     * @see RunePages
-     * @throws RiotApiException
-     */
-    public Map<String, RunePages> getRunePages(long... summonerIds) throws RiotApiException {
+		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerIds);
+	}
 
-        return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerIds);
-    }
-    
-    /**
-     * Get the rune pages of a given summoner
-     *
-     * @param summonerId The IDs of the desired summoner
-     * @return A map of rune pages of the given summoner
-     * @see RunePages
-     * @throws RiotApiException
-     */
-    public RunePages getRunePages(long summonerId) throws RiotApiException {
+	/**
+	 * Get the rune pages of a given summoner
+	 *
+	 * @param region
+	 *            Region where to retrieve the data.
+	 * @param summonerId
+	 *            Summoner ID associated with runes to retrieve.
+	 * @return A map of rune pages of the given summoner
+	 * @see RunePages
+	 * @throws RiotApiException
+	 */
+	public RunePages getRunePages(Region region, long summonerId) throws RiotApiException {
 
-        return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
-    }
+		return SummonerApi.getRunePages(region.getEndpoint(), region.getName(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
+
+	/**
+	 * Get the rune pages of multiple given summoners
+	 *
+	 * @param summonerIds
+	 *            List of summoner IDs associated with runes to retrieve. Maximum allowed at once is 40.
+	 * @return A map of rune pages of the given summoners
+	 * @see RunePages
+	 * @throws RiotApiException
+	 */
+	public Map<String, RunePages> getRunePages(long... summonerIds) throws RiotApiException {
+
+		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerIds);
+	}
+
+	/**
+	 * Get the rune pages of a given summoner
+	 *
+	 * @param summonerId
+	 *            Summoner ID associated with runes to retrieve.
+	 * @return A map of rune pages of the given summoner
+	 * @see RunePages
+	 * @throws RiotApiException
+	 */
+	public RunePages getRunePages(long summonerId) throws RiotApiException {
+
+		return SummonerApi.getRunePages(getEndpoint(), getRegion(), getKey(), summonerId).get(Long.toString(summonerId));
+	}
 
     /**
      * Get summoners by names

--- a/src/main/java/riotapi/RiotApiException.java
+++ b/src/main/java/riotapi/RiotApiException.java
@@ -8,51 +8,51 @@ public class RiotApiException extends Exception {
 
 	private static final long serialVersionUID = 2658256159686373725L;
 	public static final int BAD_REQUEST = 400;
-    public static final int FORBIDDEN = 403;
-    public static final int DATA_NOT_FOUND = 404;
-    public static final int UNAUTHORIZED = 401;
-    public static final int UNPROCESSABLE_ENTITY = 422;
-    public static final int RATE_LIMITED = 429;
-    public static final int SERVER_ERROR = 500;
-    public static final int UNAVAILABLE = 503;
-    public static final int PARSE_FAILURE = 600;
-    public static final int IOEXCEPTION = 601;
+	public static final int FORBIDDEN = 403;
+	public static final int DATA_NOT_FOUND = 404;
+	public static final int UNAUTHORIZED = 401;
+	public static final int UNPROCESSABLE_ENTITY = 422;
+	public static final int RATE_LIMITED = 429;
+	public static final int SERVER_ERROR = 500;
+	public static final int UNAVAILABLE = 503;
+	public static final int PARSE_FAILURE = 600;
+	public static final int IOEXCEPTION = 601;
 
-    private final int errorCode;
+	private final int errorCode;
 
-    public RiotApiException(final int errorCode) {
-        super(getMessage(errorCode));
-        this.errorCode = errorCode;
-    }
+	public RiotApiException(final int errorCode) {
+		super(getMessage(errorCode));
+		this.errorCode = errorCode;
+	}
 
-    public static String getMessage(final int errorCode) {
-        switch (errorCode) {
-            case BAD_REQUEST:
-                return "Bad request";
-            case FORBIDDEN:
-                return "Forbidden";
-            case DATA_NOT_FOUND:
-                return "Requested data not found";
-            case IOEXCEPTION:
-            	return "I/O Exception thrown";
-            case PARSE_FAILURE:
-                return "Failed to parse Riot's JSON response";
-            case UNPROCESSABLE_ENTITY:
-                return "Summoner has an entry, but hasn't played since the start of 2013";
-            case RATE_LIMITED:
-                return "Rate limit exceeded";
-            case SERVER_ERROR:
-                return "Internal server error";
-            case UNAUTHORIZED:
-                return "Unauthorized";
-            case UNAVAILABLE:
-                return "Service unavailable";
-            default:
-                return "An unknown API error occured";
-        }
-    }
+	public static String getMessage(final int errorCode) {
+		switch (errorCode) {
+		case BAD_REQUEST:
+			return "Bad request";
+		case FORBIDDEN:
+			return "Forbidden";
+		case DATA_NOT_FOUND:
+			return "Requested data not found";
+		case IOEXCEPTION:
+			return "I/O Exception thrown";
+		case PARSE_FAILURE:
+			return "Failed to parse Riot's JSON response";
+		case UNPROCESSABLE_ENTITY:
+			return "Summoner has an entry, but hasn't played since the start of 2013";
+		case RATE_LIMITED:
+			return "Rate limit exceeded";
+		case SERVER_ERROR:
+			return "Internal server error";
+		case UNAUTHORIZED:
+			return "Unauthorized";
+		case UNAVAILABLE:
+			return "Service unavailable";
+		default:
+			return "An unknown API error occured";
+		}
+	}
 
-    public int getErrorCode() {
-        return this.errorCode;
-    }
+	public int getErrorCode() {
+		return this.errorCode;
+	}
 }

--- a/src/main/java/riotapi/RiotStringNotFound.java
+++ b/src/main/java/riotapi/RiotStringNotFound.java
@@ -3,11 +3,11 @@ package main.java.riotapi;
 public class RiotStringNotFound extends Exception {
 
 	private static final long serialVersionUID = 1401308670684857994L;
-	
+
 	public RiotStringNotFound(String msg) {
 		super(msg);
 	}
-	
+
 	public String getMessage() {
 		return super.getMessage();
 	}

--- a/src/main/java/riotapi/StaticDataApi.java
+++ b/src/main/java/riotapi/StaticDataApi.java
@@ -80,8 +80,7 @@ final class StaticDataApi {
 		return championList;
 	}
 
-	public static Champion getDataChampion(String region, String key, int id, String locale, String version, ChampData... champData)
-			throws RiotApiException {
+	public static Champion getDataChampion(String region, String key, int id, String locale, String version, ChampData... champData) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "champion/" + id + "?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";

--- a/src/main/java/riotapi/StaticDataApi.java
+++ b/src/main/java/riotapi/StaticDataApi.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
+import constant.Region;
 import constant.staticdata.ChampData;
 import constant.staticdata.ItemData;
 import constant.staticdata.ItemListData;
@@ -48,7 +49,7 @@ final class StaticDataApi {
 	private static final String VERSION = "/v1.2/";
 	private static final String STATIC_DATA_ENDPOINT = "https://global.api.pvp.net/api/lol/static-data/";
 
-	public static ChampionList getDataChampionList(String region, String key, String locale, String version, boolean dataById, ChampData... champData)
+	public static ChampionList getDataChampionList(Region region, String key, String locale, String version, boolean dataById, ChampData... champData)
 			throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "champion?";
 		if (locale != null) {
@@ -80,7 +81,7 @@ final class StaticDataApi {
 		return championList;
 	}
 
-	public static Champion getDataChampion(String region, String key, int id, String locale, String version, ChampData... champData) throws RiotApiException {
+	public static Champion getDataChampion(Region region, String key, int id, String locale, String version, ChampData... champData) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "champion/" + id + "?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";
@@ -110,7 +111,7 @@ final class StaticDataApi {
 		return champion;
 	}
 
-	public static ItemList getDataItemList(String region, String key, String locale, String version, ItemListData... itemListData) throws RiotApiException {
+	public static ItemList getDataItemList(Region region, String key, String locale, String version, ItemListData... itemListData) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "item?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";
@@ -140,7 +141,7 @@ final class StaticDataApi {
 		return itemList;
 	}
 
-	public static Item getDataItem(String region, String key, int id, String locale, String version, ItemData... itemData) throws RiotApiException {
+	public static Item getDataItem(Region region, String key, int id, String locale, String version, ItemData... itemData) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "item/" + id + "?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";
@@ -170,7 +171,7 @@ final class StaticDataApi {
 		return item;
 	}
 
-	public static Realm getDataRealm(String region, String key) throws RiotApiException {
+	public static Realm getDataRealm(Region region, String key) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "realm?api_key=" + key;
 
 		Realm realm = null;
@@ -186,7 +187,7 @@ final class StaticDataApi {
 		return realm;
 	}
 
-	public static RuneList getDataRuneList(String region, String key, String locale, String version, RuneListData... runeListData) throws RiotApiException {
+	public static RuneList getDataRuneList(Region region, String key, String locale, String version, RuneListData... runeListData) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "rune?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";
@@ -216,7 +217,7 @@ final class StaticDataApi {
 		return runeList;
 	}
 
-	public static Rune getDataRune(String region, String key, int id, String locale, String version, RuneData... runeData) throws RiotApiException {
+	public static Rune getDataRune(Region region, String key, int id, String locale, String version, RuneData... runeData) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "rune/" + id + "?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";
@@ -246,7 +247,7 @@ final class StaticDataApi {
 		return rune;
 	}
 
-	public static MasteryList getDataMasteryList(String region, String key, String locale, String version, MasteryListData... masteryListData)
+	public static MasteryList getDataMasteryList(Region region, String key, String locale, String version, MasteryListData... masteryListData)
 			throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "mastery?";
 		if (locale != null) {
@@ -277,7 +278,7 @@ final class StaticDataApi {
 		return masteryList;
 	}
 
-	public static Mastery getDataMastery(String region, String key, int id, String locale, String version, MasteryData... masteryData) throws RiotApiException {
+	public static Mastery getDataMastery(Region region, String key, int id, String locale, String version, MasteryData... masteryData) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "mastery/" + id + "?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";
@@ -307,7 +308,7 @@ final class StaticDataApi {
 		return mastery;
 	}
 
-	public static SummonerSpellList getDataSummonerSpellList(String region, String key, String locale, String version, boolean dataById, SpellData... spellData)
+	public static SummonerSpellList getDataSummonerSpellList(Region region, String key, String locale, String version, boolean dataById, SpellData... spellData)
 			throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "summoner-spell?";
 		if (locale != null) {
@@ -339,7 +340,7 @@ final class StaticDataApi {
 		return spellList;
 	}
 
-	public static SummonerSpell getDataSummonerSpell(String region, String key, int id, String locale, String version, SpellData... spellData)
+	public static SummonerSpell getDataSummonerSpell(Region region, String key, int id, String locale, String version, SpellData... spellData)
 			throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "summoner-spell/" + id + "?";
 		if (locale != null) {
@@ -370,7 +371,7 @@ final class StaticDataApi {
 		return spell;
 	}
 
-	public static List<String> getDataVersions(String region, String key) throws RiotApiException {
+	public static List<String> getDataVersions(Region region, String key) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "versions?api_key=" + key;
 
 		List<String> versions = null;
@@ -387,7 +388,7 @@ final class StaticDataApi {
 		return versions;
 	}
 
-	public static List<String> getDataLanguages(String region, String key) throws RiotApiException {
+	public static List<String> getDataLanguages(Region region, String key) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "languages?api_key=" + key;
 
 		List<String> languages = null;
@@ -404,7 +405,7 @@ final class StaticDataApi {
 		return languages;
 	}
 
-	public static GameMapList getDataGameMapList(String region, String key, String locale, String version) throws RiotApiException {
+	public static GameMapList getDataGameMapList(Region region, String key, String locale, String version) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "map?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";
@@ -427,7 +428,7 @@ final class StaticDataApi {
 		return gameMapList;
 	}
 
-	public static LanguageStrings getDataLanguageStrings(String region, String key, String locale, String version) throws RiotApiException {
+	public static LanguageStrings getDataLanguageStrings(Region region, String key, String locale, String version) throws RiotApiException {
 		String url = STATIC_DATA_ENDPOINT + region + VERSION + "language-strings?";
 		if (locale != null) {
 			url += "locale=" + locale + "&";

--- a/src/main/java/riotapi/StatsApi.java
+++ b/src/main/java/riotapi/StatsApi.java
@@ -18,6 +18,8 @@ package main.java.riotapi;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
+import constant.Region;
+import constant.Season;
 import dto.Stats.PlayerStatsSummaryList;
 import dto.Stats.RankedStats;
 
@@ -25,21 +27,8 @@ final class StatsApi {
 
 	private static final String VERSION = "/v1.3/";
 
-	/**
-	 * Get a summary of player statistics for a given summoner
-	 *
-	 * @param region
-	 *            The desired region
-	 * @param summonerId
-	 *            The ID of the desired summoner
-	 * @param season
-	 *            The desired season
-	 * @return A summary of player statistics for the given summoner
-	 * @see PlayerStatsSummaryList
-	 */
-	public static PlayerStatsSummaryList getPlayerStatsSummary(String endpoint, String region, String season, String key, long summonerId)
-			throws RiotApiException {
-		String url = endpoint + region + VERSION + "stats/by-summoner/" + summonerId + "/summary?";
+	public static PlayerStatsSummaryList getPlayerStatsSummary(Region region, Season season, String key, long summonerId) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "stats/by-summoner/" + summonerId + "/summary?";
 		if (season != null) {
 			url += "season=" + season + "&";
 		}
@@ -58,20 +47,8 @@ final class StatsApi {
 		return summaryList;
 	}
 
-	/**
-	 * Get the ranked statistics of a given summoner
-	 *
-	 * @param region
-	 *            The desired region
-	 * @param summonerId
-	 *            The ID of the desired summoner
-	 * @param season
-	 *            The desired season
-	 * @return Ranked statistics of the given summoner
-	 * @see RankedStats
-	 */
-	public static RankedStats getRankedStats(String endpoint, String region, String season, String key, long summonerId) throws RiotApiException {
-		String url = endpoint + region + VERSION + "stats/by-summoner/" + summonerId + "/ranked?";
+	public static RankedStats getRankedStats(Region region, Season season, String key, long summonerId) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "stats/by-summoner/" + summonerId + "/ranked?";
 		if (season != null) {
 			url += "season=" + season + "&";
 		}

--- a/src/main/java/riotapi/StatusApi.java
+++ b/src/main/java/riotapi/StatusApi.java
@@ -29,7 +29,6 @@ final class StatusApi {
 	private static final String VERSION = "/v1.0/";
 
 	public static List<Shard> getShards() throws RiotApiException {
-
 		String url = "http://status.leagueoflegends.com/shards";
 
 		List<Shard> shards = null;
@@ -47,7 +46,6 @@ final class StatusApi {
 	}
 
 	public static ShardStatus getShardStatus(String region) throws RiotApiException {
-
 		String url = "http://status.leagueoflegends.com/shards/" + region;
 
 		ShardStatus status = null;

--- a/src/main/java/riotapi/StatusApi.java
+++ b/src/main/java/riotapi/StatusApi.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
+import constant.Region;
 import dto.Status.Shard;
 import dto.Status.ShardStatus;
 
@@ -45,7 +46,7 @@ final class StatusApi {
 		return shards;
 	}
 
-	public static ShardStatus getShardStatus(String region) throws RiotApiException {
+	public static ShardStatus getShardStatus(Region region) throws RiotApiException {
 		String url = "http://status.leagueoflegends.com/shards/" + region;
 
 		ShardStatus status = null;

--- a/src/main/java/riotapi/SummonerApi.java
+++ b/src/main/java/riotapi/SummonerApi.java
@@ -99,10 +99,6 @@ final class SummonerApi {
 		return summoners;
 	}
 
-	public static Map<String, Summoner> getSummonersById(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getSummonersById(endpoint, region, key, Convert.longToString(summonerIds));
-	}
-
 	public static Map<String, Summoner> getSummonersById(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
 		String url = endpoint + region + VERSION + "summoner/" + summonerIds + "?api_key=" + key;
 
@@ -120,8 +116,8 @@ final class SummonerApi {
 		return summoners;
 	}
 
-	public static Map<String, String> getSummonerNames(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getSummonerNames(endpoint, region, key, Convert.longToString(summonerIds));
+	public static Map<String, Summoner> getSummonersById(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
+		return getSummonersById(endpoint, region, key, Convert.longToString(summonerIds));
 	}
 
 	public static Map<String, String> getSummonerNames(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
@@ -139,5 +135,9 @@ final class SummonerApi {
 		}
 
 		return summonerNames;
+	}
+
+	public static Map<String, String> getSummonerNames(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
+		return getSummonerNames(endpoint, region, key, Convert.longToString(summonerIds));
 	}
 }

--- a/src/main/java/riotapi/SummonerApi.java
+++ b/src/main/java/riotapi/SummonerApi.java
@@ -25,6 +25,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
+import constant.Region;
 import dto.Summoner.MasteryPages;
 import dto.Summoner.RunePages;
 import dto.Summoner.Summoner;
@@ -33,8 +34,8 @@ final class SummonerApi {
 
 	private static final String VERSION = "/v1.4/";
 
-	public static Map<String, MasteryPages> getMasteryPages(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "summoner/" + summonerIds + "/masteries?api_key=" + key;
+	public static Map<String, MasteryPages> getMasteryPages(Region region, String key, String summonerIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "summoner/" + summonerIds + "/masteries?api_key=" + key;
 
 		Map<String, MasteryPages> masteryPages = null;
 		try {
@@ -50,12 +51,12 @@ final class SummonerApi {
 		return masteryPages;
 	}
 
-	public static Map<String, MasteryPages> getMasteryPages(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getMasteryPages(endpoint, region, key, Convert.longToString(summonerIds));
+	public static Map<String, MasteryPages> getMasteryPages(Region region, String key, long... summonerIds) throws RiotApiException {
+		return getMasteryPages(region, key, Convert.longToString(summonerIds));
 	}
 
-	public static Map<String, RunePages> getRunePages(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "summoner/" + summonerIds + "/runes?api_key=" + key;
+	public static Map<String, RunePages> getRunePages(Region region, String key, String summonerIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "summoner/" + summonerIds + "/runes?api_key=" + key;
 
 		Map<String, RunePages> runePages = null;
 		try {
@@ -71,16 +72,16 @@ final class SummonerApi {
 		return runePages;
 	}
 
-	public static Map<String, RunePages> getRunePages(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getRunePages(endpoint, region, key, Convert.longToString(summonerIds));
+	public static Map<String, RunePages> getRunePages(Region region, String key, long... summonerIds) throws RiotApiException {
+		return getRunePages(region, key, Convert.longToString(summonerIds));
 	}
 
-	public static Map<String, Summoner> getSummonersByName(String endpoint, String region, String key, String summonerNames) throws RiotApiException {
+	public static Map<String, Summoner> getSummonersByName(Region region, String key, String summonerNames) throws RiotApiException {
 		summonerNames = summonerNames.replaceAll("\\s+", "");
 
 		String url = null;
 		try {
-			url = endpoint + region + VERSION + "summoner/by-name/" + URLEncoder.encode(summonerNames, "UTF-8") + "?api_key=" + key;
+			url = region.getEndpoint() + VERSION + "summoner/by-name/" + URLEncoder.encode(summonerNames, "UTF-8") + "?api_key=" + key;
 		} catch (UnsupportedEncodingException e1) {
 			e1.printStackTrace();
 		}
@@ -99,8 +100,8 @@ final class SummonerApi {
 		return summoners;
 	}
 
-	public static Map<String, Summoner> getSummonersById(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "summoner/" + summonerIds + "?api_key=" + key;
+	public static Map<String, Summoner> getSummonersById(Region region, String key, String summonerIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "summoner/" + summonerIds + "?api_key=" + key;
 
 		Map<String, Summoner> summoners = null;
 		try {
@@ -116,12 +117,12 @@ final class SummonerApi {
 		return summoners;
 	}
 
-	public static Map<String, Summoner> getSummonersById(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getSummonersById(endpoint, region, key, Convert.longToString(summonerIds));
+	public static Map<String, Summoner> getSummonersById(Region region, String key, long... summonerIds) throws RiotApiException {
+		return getSummonersById(region, key, Convert.longToString(summonerIds));
 	}
 
-	public static Map<String, String> getSummonerNames(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "summoner/" + summonerIds + "/name?api_key=" + key;
+	public static Map<String, String> getSummonerNames(Region region, String key, String summonerIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "summoner/" + summonerIds + "/name?api_key=" + key;
 
 		Map<String, String> summonerNames = null;
 		try {
@@ -137,7 +138,7 @@ final class SummonerApi {
 		return summonerNames;
 	}
 
-	public static Map<String, String> getSummonerNames(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getSummonerNames(endpoint, region, key, Convert.longToString(summonerIds));
+	public static Map<String, String> getSummonerNames(Region region, String key, long... summonerIds) throws RiotApiException {
+		return getSummonerNames(region, key, Convert.longToString(summonerIds));
 	}
 }

--- a/src/main/java/riotapi/TeamApi.java
+++ b/src/main/java/riotapi/TeamApi.java
@@ -24,14 +24,15 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
+import constant.Region;
 import dto.Team.Team;
 
 final class TeamApi {
 
 	private static final String VERSION = "/v2.4/";
 
-	public static Map<String, List<Team>> getTeamsBySummonerIds(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "team/by-summoner/" + summonerIds + "?api_key=" + key;
+	public static Map<String, List<Team>> getTeamsBySummonerIds(Region region, String key, String summonerIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "team/by-summoner/" + summonerIds + "?api_key=" + key;
 
 		Map<String, List<Team>> teams = null;
 		try {
@@ -47,12 +48,12 @@ final class TeamApi {
 		return teams;
 	}
 
-	public static Map<String, List<Team>> getTeamsBySummonerIds(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		return getTeamsBySummonerIds(endpoint, region, key, Convert.longToString(summonerIds));
+	public static Map<String, List<Team>> getTeamsBySummonerIds(Region region, String key, long... summonerIds) throws RiotApiException {
+		return getTeamsBySummonerIds(region, key, Convert.longToString(summonerIds));
 	}
 
-	public static Map<String, List<Team>> getTeamsByTeamIds(String endpoint, String region, String key, String teamIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "team/" + teamIds + "?api_key=" + key;
+	public static Map<String, List<Team>> getTeamsByTeamIds(Region region, String key, String teamIds) throws RiotApiException {
+		String url = region.getEndpoint() + VERSION + "team/" + teamIds + "?api_key=" + key;
 
 		Map<String, List<Team>> teams = null;
 		try {
@@ -68,7 +69,7 @@ final class TeamApi {
 		return teams;
 	}
 
-	public static Map<String, List<Team>> getTeamsByTeamIds(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
-		return getTeamsByTeamIds(endpoint, region, key, Convert.longToString(teamIds));
+	public static Map<String, List<Team>> getTeamsByTeamIds(Region region, String key, long... teamIds) throws RiotApiException {
+		return getTeamsByTeamIds(region, key, Convert.longToString(teamIds));
 	}
 }

--- a/src/main/java/riotapi/TeamApi.java
+++ b/src/main/java/riotapi/TeamApi.java
@@ -30,23 +30,6 @@ final class TeamApi {
 
 	private static final String VERSION = "/v2.4/";
 
-	public static Map<String, List<Team>> getTeamsBySummonerIds(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "team/by-summoner/" + Convert.longToString(summonerIds) + "?api_key=" + key;
-
-		Map<String, List<Team>> teams = null;
-		try {
-			teams = new Gson().fromJson(Request.execute(url), new TypeToken<Map<String, List<Team>>>() {
-			}.getType());
-		} catch (JsonSyntaxException e) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-		if (teams == null) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-
-		return teams;
-	}
-
 	public static Map<String, List<Team>> getTeamsBySummonerIds(String endpoint, String region, String key, String summonerIds) throws RiotApiException {
 		String url = endpoint + region + VERSION + "team/by-summoner/" + summonerIds + "?api_key=" + key;
 
@@ -64,21 +47,8 @@ final class TeamApi {
 		return teams;
 	}
 
-	public static Map<String, List<Team>> getTeamsByTeamIds(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
-		String url = endpoint + region + VERSION + "team/" + Convert.longToString(teamIds) + "?api_key=" + key;
-
-		Map<String, List<Team>> teams = null;
-		try {
-			teams = new Gson().fromJson(Request.execute(url), new TypeToken<Map<String, List<Team>>>() {
-			}.getType());
-		} catch (JsonSyntaxException e) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-		if (teams == null) {
-			throw new RiotApiException(RiotApiException.PARSE_FAILURE);
-		}
-
-		return teams;
+	public static Map<String, List<Team>> getTeamsBySummonerIds(String endpoint, String region, String key, long... summonerIds) throws RiotApiException {
+		return getTeamsBySummonerIds(endpoint, region, key, Convert.longToString(summonerIds));
 	}
 
 	public static Map<String, List<Team>> getTeamsByTeamIds(String endpoint, String region, String key, String teamIds) throws RiotApiException {
@@ -96,5 +66,9 @@ final class TeamApi {
 		}
 
 		return teams;
+	}
+
+	public static Map<String, List<Team>> getTeamsByTeamIds(String endpoint, String region, String key, long... teamIds) throws RiotApiException {
+		return getTeamsByTeamIds(endpoint, region, key, Convert.longToString(teamIds));
 	}
 }

--- a/src/util/Convert.java
+++ b/src/util/Convert.java
@@ -26,7 +26,7 @@ public final class Convert {
 				sb.append(',');
 			}
 		}
-		sb.append(String.valueOf(summonerIds[summonerIds.length - 1]).trim());
+		sb.append(summonerIds[summonerIds.length - 1]);
 		return sb.toString();
 	}
 }

--- a/src/util/Convert.java
+++ b/src/util/Convert.java
@@ -17,13 +17,16 @@ package util;
  */
 
 public final class Convert {
-	
-	public static String longToString(long... summonerIds){
-		String ids = "";
-		for(int i = 0; i < summonerIds.length; i++){
-			if(i != (summonerIds.length - 1)){ ids = ids + summonerIds[i] + ","; }
-			else { ids = ids + summonerIds[i]; }
+
+	public static String longToString(long... summonerIds) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < summonerIds.length - 1; i++) {
+			if (!String.valueOf(summonerIds[i]).matches(" *")) {
+				sb.append(summonerIds[i]);
+				sb.append(',');
+			}
 		}
-		return ids;
+		sb.append(String.valueOf(summonerIds[summonerIds.length - 1]).trim());
+		return sb.toString();
 	}
 }


### PR DESCRIPTION
# JavaDoc
###### Finalized my JavaDoc rework of RiotApi.java
- Every method now has updated, detailed JavaDoc descriptions
- Fixed some methods having invalid JavaDoc (refering to wrong classes or parameters)
- The class itself now has proper JavaDoc, using @author and @version. Please note that @version has to be updated on future version updates. If you permit, 'big' contributors could now add themselves as additional @author of the API

# 5 New Methods
###### Added new methods to allow summonerId input as String instead of long. I did this because many other methods already offered this, and these were missing that option.
- getTeamsBySummonerId(Region, String)
- getTeamsBySummonerId(String)
- getCurrentGameInfo(PlatformId, String)
- getRecentGames(Region, String)
- getRecentGames(String)

# Internal Code Changes
###### I tried to optimize and simplify a few procedures. With the API often being used in a multi-threaded environment for millions of calls in a single instance, even small improvements can sum up to notable improvements in performance and/or resource usage
- Optimized many methods in the individual Apis, by having duplicate methods use each other (for methods which existed for *String summonerId* and *long summonerId*)
- Optimized *Util.Convert.longToString()* with a new algorithm that uses a StringBuilder
- Added @Override toString() methods to the Constant classes to simplify usage
- RiotApi.java no longer passes *String endpoint* to the individual Apis (the endpoint is now gained by calling *region.getEndpoint()*)
- RiotApi.java now gives *Region region* (instead of *String region*) to the individual Apis (with Region now having a proper toString() method, and *Region.getEndpoint()* now returning the regionalized endpoint (unless calling *Region.getEndpoint(false)*) things are really simple now.
- RiotApi.java now gives *Season season* (instead of *String season*) to the StatsApi (like with the region change, toString() makes things really easy)


###### Some words...
GitHub will probably show a conflict in the automatic merge of this pull request because some of these files (especially RiotApi.java with all those JavaDoc and method changes) had some really major changes. As of right now it would be safe to simply overwrite the affected files though, since I used an up-to-date fork of this Api.
I already did alot of testing to avoid any errors, but it can't hurt to double-check that.