### PR TITLE
Fix GetMatch includeTimeline flag

### DIFF
--- a/src/main/java/net/rithms/riot/api/UrlParameter.java
+++ b/src/main/java/net/rithms/riot/api/UrlParameter.java
@@ -39,7 +39,7 @@ public class UrlParameter implements Cloneable {
 	}
 
 	public UrlParameter(String key, boolean value) {
-		this(key, value ? "1" : "0");
+		this(key, value ? "true" : "false");
 	}
 
 	public UrlParameter(String key, Object value) {

--- a/src/main/java/net/rithms/riot/api/endpoints/match/methods/GetMatch.java
+++ b/src/main/java/net/rithms/riot/api/endpoints/match/methods/GetMatch.java
@@ -30,7 +30,7 @@ public class GetMatch extends MatchApiMethod {
 		setReturnType(MatchDetail.class);
 		setUrlBase(region.getEndpoint() + "/v2.2/match/" + matchId);
 		if (includeTimeline) {
-			add(new UrlParameter("includeTimeline", includeTimeline));
+			add(new UrlParameter("includeTimeline", String.valueOf(includeTimeline)));
 		}
 		addApiKeyParameter();
 	}

--- a/src/main/java/net/rithms/riot/api/endpoints/match/methods/GetMatch.java
+++ b/src/main/java/net/rithms/riot/api/endpoints/match/methods/GetMatch.java
@@ -30,7 +30,7 @@ public class GetMatch extends MatchApiMethod {
 		setReturnType(MatchDetail.class);
 		setUrlBase(region.getEndpoint() + "/v2.2/match/" + matchId);
 		if (includeTimeline) {
-			add(new UrlParameter("includeTimeline", String.valueOf(includeTimeline)));
+			add(new UrlParameter("includeTimeline", includeTimeline));
 		}
 		addApiKeyParameter();
 	}


### PR DESCRIPTION
The includeTimeline flag in the GetMatch api call needs to be "true". Any other value such as "1" results in the timeline not being included. Try it out with this url.
https://na.api.pvp.net/api/lol/na/v2.2/match/2209946544?includeTimeline=true&api_key=<your-api-key>